### PR TITLE
chore: Use custom action to commit changes in CI instead of `git commit`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
           npm version ${{ env.VERSION }} --no-git-tag-version
 
       - name: Commit version update
-        uses: apify/actions/signed-commit@v1.0.0
+        uses: apify/actions/signed-commit@v1.1.2
         with:
           message: "chore(release): set version to ${{ env.VERSION }} [skip ci]"
           add: 'package.json package-lock.json'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,22 +47,11 @@ jobs:
           echo "Updating package.json to version ${{ env.VERSION }}"
           npm version ${{ env.VERSION }} --no-git-tag-version
 
-      - name: Stage version update
-        id: stage
-        run: |
-          git add package.json package-lock.json
-          if git diff --cached --quiet; then
-            echo "No changes to commit in package.json or package-lock.json for version update."
-            echo "has-changes=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has-changes=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Commit version update
-        if: steps.stage.outputs.has-changes == 'true'
-        uses: apify/workflows/commit@v0.44.0
+        uses: apify/actions/signed-commit@v1.0.0
         with:
-          commit-message: "chore(release): set version to ${{ env.VERSION }} [skip ci]"
+          message: "chore(release): set version to ${{ env.VERSION }} [skip ci]"
+          add: 'package.json package-lock.json'
           github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           branch: ${{ github.event.release.target_commitish }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,6 @@ jobs:
       - name: Run tests
         run: npm run test
 
-      - name: Configure Git
-        run: |
-          git config --global user.name "Apify Release Bot"
-          git config --global user.email "noreply@apify.com"
-
       - name: Extract release version
         id: get_version
         run: |
@@ -52,20 +47,24 @@ jobs:
           echo "Updating package.json to version ${{ env.VERSION }}"
           npm version ${{ env.VERSION }} --no-git-tag-version
 
-      - name: Commit version update
+      - name: Stage version update
+        id: stage
         run: |
           git add package.json package-lock.json
-          if ! git diff --staged --quiet; then
-            TARGET_BRANCH="${{ github.event.release.target_commitish }}"
-            echo "Target branch for push: $TARGET_BRANCH"
-            git commit -m "chore(release): set version to ${{ env.VERSION }} [skip ci]"
-            echo "Pushing version update to branch: $TARGET_BRANCH"
-            git push origin HEAD:"refs/heads/$TARGET_BRANCH"
-          else
+          if git diff --cached --quiet; then
             echo "No changes to commit in package.json or package-lock.json for version update."
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+
+      - name: Commit version update
+        if: steps.stage.outputs.has-changes == 'true'
+        uses: apify/workflows/commit@v0.44.0
+        with:
+          commit-message: "chore(release): set version to ${{ env.VERSION }} [skip ci]"
+          github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+          branch: ${{ github.event.release.target_commitish }}
 
       - name: Publish to npm
         run: |


### PR DESCRIPTION
We want to enforce commit signing for all commits in our repositories.
To do that, we need to make sure even commits created by CI workflows are signed.

It would be possible to sign using GPG keys, but that would require a lot of maintenance.

Instead, we can commit using the GitHub GraphQL API, which automatically signs commits.

This PR replaces direct `git commit` / `git push` usage (and third-party commit actions like `EndBug/add-and-commit`)
with the `apify/actions/signed-commit` action, which uses the GraphQL API under the hood.