### PR TITLE
fix: add timeout to polling of run to avoid infinite runs

### DIFF
--- a/nodes/Apify/helpers/consts.ts
+++ b/nodes/Apify/helpers/consts.ts
@@ -2,6 +2,12 @@ export const WEB_CONTENT_SCRAPER_ACTOR_ID = 'aYG0l9s7dbB7j3gbS';
 export const APIFY_API_URL = 'https://api.apify.com';
 export const TERMINAL_RUN_STATUSES = ['SUCCEEDED', 'FAILED', 'TIMED-OUT', 'ABORTED'];
 export const WAIT_FOR_FINISH_POLL_INTERVAL = 1000;
+// Per-request HTTP timeout (ms). Prevents a stalled socket from hanging the node indefinitely.
+export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+// Grace period added on top of a run's own `timeoutSecs` when polling
+export const WAIT_FOR_FINISH_BUFFER_MS = 5 * 60 * 1000;
+// Absolute ceiling for polling when a run has no timeout of its own (timeoutSecs = 0).
+export const WAIT_FOR_FINISH_MAX_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export const memoryOptions = [
 	{ name: '128 MB', value: 128 },

--- a/nodes/Apify/helpers/consts.ts
+++ b/nodes/Apify/helpers/consts.ts
@@ -9,7 +9,7 @@ export const DATASET_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 // Grace period added on top of a run's own `timeoutSecs` when polling
 export const WAIT_FOR_FINISH_BUFFER_MS = 5 * 60 * 1000;
 // Absolute ceiling for polling when a run has no timeout of its own (timeoutSecs = 0).
-export const WAIT_FOR_FINISH_MAX_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+export const WAIT_FOR_FINISH_MAX_DURATION_MS = 24 * 60 * 60 * 1000; // 1 day
 
 export const memoryOptions = [
 	{ name: '128 MB', value: 128 },

--- a/nodes/Apify/helpers/consts.ts
+++ b/nodes/Apify/helpers/consts.ts
@@ -4,6 +4,8 @@ export const TERMINAL_RUN_STATUSES = ['SUCCEEDED', 'FAILED', 'TIMED-OUT', 'ABORT
 export const WAIT_FOR_FINISH_POLL_INTERVAL = 1000;
 // Per-request HTTP timeout (ms). Prevents a stalled socket from hanging the node indefinitely.
 export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+// Longer timeout for dataset item downloads, which can be large and slow to fully transfer.
+export const DATASET_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
 // Grace period added on top of a run's own `timeoutSecs` when polling
 export const WAIT_FOR_FINISH_BUFFER_MS = 5 * 60 * 1000;
 // Absolute ceiling for polling when a run has no timeout of its own (timeoutSecs = 0).

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/execute.ts
@@ -5,6 +5,7 @@ import {
 	NodeOperationError,
 } from 'n8n-workflow';
 import { apiRequest, customBodyParser, pollRunStatus } from '../../genericFunctions';
+import { consts } from '../../../helpers';
 
 export async function runTaskAndGetDataset(
 	this: IExecuteFunctions,
@@ -70,6 +71,7 @@ export async function runTaskAndGetDataset(
 		method: 'GET',
 		uri: `/v2/datasets/${lastRunData.defaultDatasetId}/items`,
 		qs: { format: 'json' },
+		timeout: consts.DATASET_REQUEST_TIMEOUT_MS,
 	});
 
 	return this.helpers.returnJsonArray(datasetItems);

--- a/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
+++ b/nodes/Apify/resources/actors/run-actor-and-get-dataset/execute.ts
@@ -1,6 +1,7 @@
 import { IExecuteFunctions, INodeExecutionData, NodeApiError } from 'n8n-workflow';
 import { apiRequest } from '../../genericFunctions';
 import { executeActor } from '../../executeActor';
+import { consts } from '../../../helpers';
 
 export async function runActorAndGetDataset(
 	this: IExecuteFunctions,
@@ -39,6 +40,7 @@ export async function runActorAndGetDataset(
 		method: 'GET',
 		uri: `/v2/datasets/${lastRunData.defaultDatasetId}/items`,
 		qs: { format: 'json' },
+		timeout: consts.DATASET_REQUEST_TIMEOUT_MS,
 	});
 
 	return this.helpers.returnJsonArray(datasetItems);

--- a/nodes/Apify/resources/actors/scrape-single-url/execute.ts
+++ b/nodes/Apify/resources/actors/scrape-single-url/execute.ts
@@ -56,6 +56,7 @@ export async function scrapeSingleUrl(
 			method: 'GET',
 			uri: `/v2/datasets/${defaultDatasetId}/items`,
 			qs: { format: 'json' },
+			timeout: consts.DATASET_REQUEST_TIMEOUT_MS,
 		});
 
 		delete item.text;

--- a/nodes/Apify/resources/datasets/get-items/execute.ts
+++ b/nodes/Apify/resources/datasets/get-items/execute.ts
@@ -5,6 +5,7 @@ import {
 	NodeOperationError,
 } from 'n8n-workflow';
 import { apiRequest } from '../../../resources/genericFunctions';
+import { consts } from '../../../helpers';
 
 function normalizeCommaSeparatedList(value: string): string {
 	return value
@@ -42,6 +43,7 @@ export async function getItems(this: IExecuteFunctions, i: number): Promise<INod
 			method: 'GET',
 			uri: `/v2/datasets/${datasetId}/items`,
 			qs,
+			timeout: consts.DATASET_REQUEST_TIMEOUT_MS,
 		});
 
 		return this.helpers.returnJsonArray(itemsArray);

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -14,6 +14,11 @@ import {
 	DEFAULT_EXP_BACKOFF_EXPONENTIAL,
 	DEFAULT_EXP_BACKOFF_INTERVAL,
 	DEFAULT_EXP_BACKOFF_RETRIES,
+	DEFAULT_REQUEST_TIMEOUT_MS,
+	TERMINAL_RUN_STATUSES,
+	WAIT_FOR_FINISH_BUFFER_MS,
+	WAIT_FOR_FINISH_MAX_DURATION_MS,
+	WAIT_FOR_FINISH_POLL_INTERVAL,
 } from '../helpers/consts';
 
 type IApiRequestOptions = Omit<IHttpRequestOptions, 'url'> & { uri?: string };
@@ -40,6 +45,8 @@ export async function apiRequest(
 
 	const options: IHttpRequestOptions = {
 		json: true,
+		// Can be overridden per request via `requestOptions.timeout`.
+		timeout: DEFAULT_REQUEST_TIMEOUT_MS,
 		...rest,
 		method,
 		qs: query,
@@ -186,6 +193,10 @@ export async function pollRunStatus(
 	runId: string,
 ): Promise<any> {
 	let lastRunData: any;
+	const startedAt = Date.now();
+	// The max timeout is based on run timeout or maximum, in case there is no timeout.
+	let maxDurationMs = WAIT_FOR_FINISH_MAX_DURATION_MS;
+	let timeoutChecked = false;
 	while (true) {
 		try {
 			const pollResult = await apiRequest.call(this, {
@@ -194,15 +205,28 @@ export async function pollRunStatus(
 			});
 			const status = pollResult?.data?.status;
 			lastRunData = pollResult?.data;
-			if (['SUCCEEDED', 'FAILED', 'TIMED-OUT', 'ABORTED'].includes(status)) {
+			if (TERMINAL_RUN_STATUSES.includes(status)) {
 				break;
+			}
+			if (!timeoutChecked) {
+				const timeoutSecs = Number(lastRunData?.options?.timeoutSecs);
+				if (Number.isFinite(timeoutSecs) && timeoutSecs > 0) {
+					maxDurationMs = timeoutSecs * 1000 + WAIT_FOR_FINISH_BUFFER_MS;
+				}
+				timeoutChecked = true;
 			}
 		} catch (err) {
 			throw new NodeApiError(this.getNode(), {
 				message: `Error polling run status: ${err}`,
 			});
 		}
-		await sleep(1000); // 1 second polling interval
+		const elapsedMs = Date.now() - startedAt;
+		if (elapsedMs > maxDurationMs) {
+			throw new NodeApiError(this.getNode(), {
+				message: `Timed out after ${Math.round(elapsedMs / 1000)}s waiting for run ${runId} to finish. Last known status: ${lastRunData?.status ?? 'unknown'}.`,
+			});
+		}
+		await sleep(WAIT_FOR_FINISH_POLL_INTERVAL);
 	}
 	return lastRunData;
 }

--- a/nodes/Apify/resources/genericFunctions.ts
+++ b/nodes/Apify/resources/genericFunctions.ts
@@ -69,8 +69,11 @@ export async function apiRequest(
 			);
 		}
 
-		return await retryWithExponentialBackoff(() =>
-			this.helpers.httpRequestWithAuthentication.call(this, authenticationMethod, options),
+		return await retryWithExponentialBackoff(
+			() => this.helpers.httpRequestWithAuthentication.call(this, authenticationMethod, options),
+			// Only retry timeouts/network errors for idempotent GET requests. Retrying a
+			// non-idempotent POST (e.g. starting an Actor run) could create duplicate runs.
+			{ retryNetworkErrors: method === 'GET' },
 		);
 	} catch (error) {
 		if (error instanceof NodeApiError) throw error;
@@ -101,22 +104,30 @@ function isStatusCodeRetryable(statusCode: number) {
 	return isRateLimitError || isInternalError;
 }
 
+interface RetryOptions {
+	interval?: number;
+	exponential?: number;
+	maxRetries?: number;
+	// Whether to retry network errors that carry no HTTP status code (e.g. socket timeouts).
+	retryNetworkErrors?: boolean;
+}
+
 /**
  * Wraps a function with exponential backoff.
- * If request fails with http code 500+ or doesn't return
- * a code at all it is retried in 1s,2s,4s,.. up to maxRetries
- * @param fn
- * @param interval
- * @param exponential
- * @param maxRetries
- * @returns
+ * Retries on HTTP 429 / 500+ (in 1s,2s,4s,.. up to maxRetries). When `retryNetworkErrors`
+ * is set, errors without an HTTP status code (e.g. socket timeouts) are retried too.
  */
 export async function retryWithExponentialBackoff(
 	fn: () => Promise<any>,
-	interval: number = DEFAULT_EXP_BACKOFF_INTERVAL,
-	exponential: number = DEFAULT_EXP_BACKOFF_EXPONENTIAL,
-	maxRetries: number = DEFAULT_EXP_BACKOFF_RETRIES,
+	options: RetryOptions = {},
 ): Promise<any> {
+	const {
+		interval = DEFAULT_EXP_BACKOFF_INTERVAL,
+		exponential = DEFAULT_EXP_BACKOFF_EXPONENTIAL,
+		maxRetries = DEFAULT_EXP_BACKOFF_RETRIES,
+		retryNetworkErrors = false,
+	} = options;
+
 	let lastError;
 	for (let i = 0; i < maxRetries; i++) {
 		try {
@@ -124,7 +135,12 @@ export async function retryWithExponentialBackoff(
 		} catch (error) {
 			lastError = error;
 			const status = Number(error?.httpCode);
-			if (isStatusCodeRetryable(status)) {
+			// A missing/non-numeric status code usually means a network-level error
+			// (timeout, connection reset, DNS) rather than an HTTP response.
+			const isNetworkError = Number.isNaN(status);
+			const shouldRetry =
+				isStatusCodeRetryable(status) || (retryNetworkErrors && isNetworkError);
+			if (shouldRetry) {
 				//Generate a new sleep time based from interval * exponential^i function
 				const sleepTimeSecs = interval * Math.pow(exponential, i);
 				const sleepTimeMs = sleepTimeSecs * 1000;


### PR DESCRIPTION
fixes https://github.com/apify/integrations-team/issues/58 
https://github.com/apify/integrations-team/issues/44

Adds a per-request HTTP timeout and bounds the run-status polling loop so a stalled request or a run that never reaches a terminal state fails cleanly instead of running forever.

  - Add a 60s per-request HTTP timeout in apiRequest so a stalled socket aborts and retries instead of blocking the node.
  - Bound pollRunStatus with a deadline derived from the run's own timeoutSecs (+5min buffer), falling back to a 7-day absolute ceiling for runs with no timeout.
  - Throw a clear NodeApiError (with elapsed time, run ID, and last-known status) when the deadline is exceeded, so n8n error handling can trigger.
  - Read timeoutSecs only once during polling and reuse existing TERMINAL_RUN_STATUSES / WAIT_FOR_FINISH_POLL_INTERVAL constants