### PR TITLE
chore: update npm dependencies

### DIFF
--- a/nodes/Apify/__tests__/utils/credentialHelper.ts
+++ b/nodes/Apify/__tests__/utils/credentialHelper.ts
@@ -26,6 +26,18 @@ export class CredentialsHelper extends ICredentialsHelper {
 		return [];
 	}
 
+	isCredentialUsableByNode(credentialType: string, nodeType: string): boolean {
+		return true;
+	}
+
+	async runPreAuthentication(
+		helpers: IHttpRequestHelper,
+		credentials: ICredentialDataDecryptedObject,
+		typeName: string,
+	): Promise<ICredentialDataDecryptedObject | undefined> {
+		return undefined;
+	}
+
 	async authenticate(
 		credentials: ICredentialDataDecryptedObject,
 		typeName: string,

--- a/nodes/Apify/__tests__/utils/executeWorkflow.ts
+++ b/nodes/Apify/__tests__/utils/executeWorkflow.ts
@@ -209,6 +209,7 @@ export const executeWorkflow = async ({
 	const executionData: IRun = {
 		mode: 'manual',
 		status: 'success',
+		storedAt: 'db',
 		data: createRunExecutionData({
 			resultData: {
 				runData: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
 			"devDependencies": {
 				"@n8n/node-cli": "^0.37.2",
 				"@types/jest": "^29.5.14",
-				"@types/node": "^24.0.1",
-				"eslint": "^9.32.0",
+				"@types/node": "^24.13.2",
+				"eslint": "^9.39.4",
 				"gulp": "^5.0.1",
 				"jest": "^29.7.0",
-				"nock": "^14.0.5",
-				"prettier": "^3.3.2",
-				"ts-jest": "^29.3.2",
+				"nock": "^14.0.16",
+				"prettier": "^3.9.4",
+				"ts-jest": "^29.4.11",
 				"typescript": "5.5.3"
 			},
 			"engines": {
@@ -759,15 +759,15 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.2"
+				"minimatch": "^3.1.5"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -824,20 +824,20 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"debug": "^4.3.2",
 				"espree": "^10.0.1",
 				"globals": "^14.0.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.1",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.5",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
@@ -872,9 +872,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-			"integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1878,9 +1878,9 @@
 			}
 		},
 		"node_modules/@mswjs/interceptors": {
-			"version": "0.39.8",
-			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.8.tgz",
-			"integrity": "sha512-2+BzZbjRO7Ct61k8fMNHEtoKjeWI9pIlHFTqBwZ5icHpqszIgEZbjb1MW5Z0+bITTCTl3gk4PDBxs9tA/csXvA==",
+			"version": "0.41.9",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+			"integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2831,6 +2831,41 @@
 				}
 			}
 		},
+		"node_modules/@n8n/node-cli/node_modules/eslint-import-resolver-typescript": {
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+			"integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"debug": "^4.4.1",
+				"eslint-import-context": "^0.1.8",
+				"get-tsconfig": "^4.10.1",
+				"is-bun-module": "^2.0.0",
+				"stable-hash-x": "^0.2.0",
+				"tinyglobby": "^0.2.14",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^16.17.0 || >=18.6.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-import-resolver-typescript"
+			},
+			"peerDependencies": {
+				"eslint": "*",
+				"eslint-plugin-import": "*",
+				"eslint-plugin-import-x": "*"
+			},
+			"peerDependenciesMeta": {
+				"eslint-plugin-import": {
+					"optional": true
+				},
+				"eslint-plugin-import-x": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@n8n/node-cli/node_modules/eslint-visitor-keys": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -3485,13 +3520,13 @@
 			"peer": true
 		},
 		"node_modules/@types/node": {
-			"version": "24.10.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
-			"integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
+			"version": "24.13.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+			"integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.16.0"
+				"undici-types": "~7.18.0"
 			}
 		},
 		"node_modules/@types/node-fetch": {
@@ -3539,20 +3574,20 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.0.tgz",
-			"integrity": "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+			"integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.53.0",
-				"@typescript-eslint/type-utils": "8.53.0",
-				"@typescript-eslint/utils": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0",
+				"@typescript-eslint/scope-manager": "8.62.1",
+				"@typescript-eslint/type-utils": "8.62.1",
+				"@typescript-eslint/utils": "8.62.1",
+				"@typescript-eslint/visitor-keys": "8.62.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.4.0"
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3562,9 +3597,9 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.53.0",
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"@typescript-eslint/parser": "^8.62.1",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -3578,16 +3613,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.0.tgz",
-			"integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+			"integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.53.0",
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0",
+				"@typescript-eslint/scope-manager": "8.62.1",
+				"@typescript-eslint/types": "8.62.1",
+				"@typescript-eslint/typescript-estree": "8.62.1",
+				"@typescript-eslint/visitor-keys": "8.62.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -3598,19 +3633,19 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.0.tgz",
-			"integrity": "sha512-Bl6Gdr7NqkqIP5yP9z1JU///Nmes4Eose6L1HwpuVHwScgDPPuEWbUVhvlZmb8hy0vX9syLk5EGNL700WcBlbg==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+			"integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.53.0",
-				"@typescript-eslint/types": "^8.53.0",
+				"@typescript-eslint/tsconfig-utils": "^8.62.1",
+				"@typescript-eslint/types": "^8.62.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -3621,18 +3656,18 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.0.tgz",
-			"integrity": "sha512-kWNj3l01eOGSdVBnfAF2K1BTh06WS0Yet6JUgb9Cmkqaz3Jlu0fdVUjj9UI8gPidBWSMqDIglmEXifSgDT/D0g==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+			"integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0"
+				"@typescript-eslint/types": "8.62.1",
+				"@typescript-eslint/visitor-keys": "8.62.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3643,9 +3678,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.0.tgz",
-			"integrity": "sha512-K6Sc0R5GIG6dNoPdOooQ+KtvT5KCKAvTcY8h2rIuul19vxH5OTQk7ArKkd4yTzkw66WnNY0kPPzzcmWA+XRmiA==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+			"integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3656,21 +3691,21 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.0.tgz",
-			"integrity": "sha512-BBAUhlx7g4SmcLhn8cnbxoxtmS7hcq39xKCgiutL3oNx1TaIp+cny51s8ewnKMpVUKQUGb41RAUWZ9kxYdovuw==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+			"integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0",
-				"@typescript-eslint/utils": "8.53.0",
+				"@typescript-eslint/types": "8.62.1",
+				"@typescript-eslint/typescript-estree": "8.62.1",
+				"@typescript-eslint/utils": "8.62.1",
 				"debug": "^4.4.3",
-				"ts-api-utils": "^2.4.0"
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3680,14 +3715,14 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
-			"integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+			"integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3699,21 +3734,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.0.tgz",
-			"integrity": "sha512-pw0c0Gdo7Z4xOG987u3nJ8akL9093yEEKv8QTJ+Bhkghj1xyj8cgPaavlr9rq8h7+s6plUJ4QJYw2gCZodqmGw==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+			"integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.53.0",
-				"@typescript-eslint/tsconfig-utils": "8.53.0",
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0",
+				"@typescript-eslint/project-service": "8.62.1",
+				"@typescript-eslint/tsconfig-utils": "8.62.1",
+				"@typescript-eslint/types": "8.62.1",
+				"@typescript-eslint/visitor-keys": "8.62.1",
 				"debug": "^4.4.3",
-				"minimatch": "^9.0.5",
+				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
 				"tinyglobby": "^0.2.15",
-				"ts-api-utils": "^2.4.0"
+				"ts-api-utils": "^2.5.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3723,20 +3758,59 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.8.4 <6.0.0"
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.0.tgz",
-			"integrity": "sha512-XDY4mXTez3Z1iRDI5mbRhH4DFSt46oaIFsLg+Zn97+sYrXACziXSQcSelMybnVZ5pa1P6xYkPr5cMJyunM1ZDA==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+			"integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.53.0",
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0"
+				"@typescript-eslint/scope-manager": "8.62.1",
+				"@typescript-eslint/types": "8.62.1",
+				"@typescript-eslint/typescript-estree": "8.62.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3746,19 +3820,19 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.0.tgz",
-			"integrity": "sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+			"integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.0",
-				"eslint-visitor-keys": "^4.2.1"
+				"@typescript-eslint/types": "8.62.1",
+				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3769,13 +3843,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -4065,9 +4139,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5030,9 +5104,9 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.4.tgz",
-			"integrity": "sha512-0D6qSQ5IkeRrGJFHRClzaMOenMeT0gErz3zIw3AprKMqhRN6LNU2jQOdkPG/FZ+8bCgXE1VidrgSzlBBDZRr8A==",
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+			"integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5436,25 +5510,25 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.2",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.1",
+				"@eslint/config-array": "^0.21.2",
 				"@eslint/config-helpers": "^0.4.2",
 				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.39.2",
+				"@eslint/eslintrc": "^3.3.5",
+				"@eslint/js": "9.39.4",
 				"@eslint/plugin-kit": "^0.4.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"ajv": "^6.12.4",
+				"ajv": "^6.14.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
@@ -5473,7 +5547,7 @@
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
+				"minimatch": "^3.1.5",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -5520,54 +5594,19 @@
 				}
 			}
 		},
-		"node_modules/eslint-import-resolver-typescript": {
-			"version": "4.4.4",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
-			"integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"debug": "^4.4.1",
-				"eslint-import-context": "^0.1.8",
-				"get-tsconfig": "^4.10.1",
-				"is-bun-module": "^2.0.0",
-				"stable-hash-x": "^0.2.0",
-				"tinyglobby": "^0.2.14",
-				"unrs-resolver": "^1.7.11"
-			},
-			"engines": {
-				"node": "^16.17.0 || >=18.6.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint-import-resolver-typescript"
-			},
-			"peerDependencies": {
-				"eslint": "*",
-				"eslint-plugin-import": "*",
-				"eslint-plugin-import-x": "*"
-			},
-			"peerDependenciesMeta": {
-				"eslint-plugin-import": {
-					"optional": true
-				},
-				"eslint-plugin-import-x": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/eslint-plugin-import-x": {
-			"version": "4.16.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.1.tgz",
-			"integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
+			"version": "4.17.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.1.tgz",
+			"integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "^8.35.0",
+				"@typescript-eslint/types": "^8.56.0",
 				"comment-parser": "^1.4.1",
 				"debug": "^4.4.1",
 				"eslint-import-context": "^0.1.9",
 				"is-glob": "^4.0.3",
-				"minimatch": "^9.0.3 || ^10.0.1",
+				"minimatch": "^9.0.3 || ^10.1.2",
 				"semver": "^7.7.2",
 				"stable-hash-x": "^0.2.0",
 				"unrs-resolver": "^1.9.2"
@@ -5579,8 +5618,8 @@
 				"url": "https://opencollective.com/eslint-plugin-import-x"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/utils": "^8.0.0",
-				"eslint": "^8.57.0 || ^9.0.0",
+				"@typescript-eslint/utils": "^8.56.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"eslint-import-resolver-node": "*"
 			},
 			"peerDependenciesMeta": {
@@ -8942,13 +8981,13 @@
 			}
 		},
 		"node_modules/nock": {
-			"version": "14.0.10",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.10.tgz",
-			"integrity": "sha512-Q7HjkpyPeLa0ZVZC5qpxBt5EyLczFJ91MEewQiIi9taWuA0KB/MDJlUWtON+7dGouVdADTQsf9RA7TZk6D8VMw==",
+			"version": "14.0.16",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.16.tgz",
+			"integrity": "sha512-8r4KEc6nT1D/fdLD/R1BO1CPaVEL8o40u/guFRJlXabN7vr3RmMqyjsY5Krt0nMwhsOAwXQ/mtN5vy5Jh3aErg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@mswjs/interceptors": "^0.39.5",
+				"@mswjs/interceptors": "^0.41.0",
 				"json-stringify-safe": "^5.0.1",
 				"propagate": "^2.0.0"
 			},
@@ -9724,9 +9763,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
-			"integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+			"version": "3.9.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+			"integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -10283,9 +10322,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -10934,9 +10973,9 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-			"integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10947,19 +10986,19 @@
 			}
 		},
 		"node_modules/ts-jest": {
-			"version": "29.4.6",
-			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-			"integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+			"version": "29.4.11",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+			"integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bs-logger": "^0.2.6",
 				"fast-json-stable-stringify": "^2.1.0",
-				"handlebars": "^4.7.8",
+				"handlebars": "^4.7.9",
 				"json5": "^2.2.3",
 				"lodash.memoize": "^4.1.2",
 				"make-error": "^1.3.6",
-				"semver": "^7.7.3",
+				"semver": "^7.8.0",
 				"type-fest": "^4.41.0",
 				"yargs-parser": "^21.1.1"
 			},
@@ -10976,7 +11015,7 @@
 				"babel-jest": "^29.0.0 || ^30.0.0",
 				"jest": "^29.0.0 || ^30.0.0",
 				"jest-util": "^29.0.0 || ^30.0.0",
-				"typescript": ">=4.3 <6"
+				"typescript": ">=4.3 <7"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {
@@ -11080,16 +11119,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.53.0.tgz",
-			"integrity": "sha512-xHURCQNxZ1dsWn0sdOaOfCSQG0HKeqSj9OexIxrz6ypU6wHYOdX2I3D2b8s8wFSsSOYJb+6q283cLiLlkEsBYw==",
+			"version": "8.62.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+			"integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.53.0",
-				"@typescript-eslint/parser": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0",
-				"@typescript-eslint/utils": "8.53.0"
+				"@typescript-eslint/eslint-plugin": "8.62.1",
+				"@typescript-eslint/parser": "8.62.1",
+				"@typescript-eslint/typescript-estree": "8.62.1",
+				"@typescript-eslint/utils": "8.62.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11099,8 +11138,8 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
 			}
 		},
 		"node_modules/uglify-js": {
@@ -11188,9 +11227,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@n8n/node-cli": "^0.37.2",
-				"@types/jest": "^29.5.14",
+				"@types/jest": "^30.0.0",
 				"@types/node": "^24.13.2",
 				"eslint": "^9.39.4",
 				"gulp": "^5.0.1",
-				"jest": "^29.7.0",
+				"jest": "^30.4.2",
 				"nock": "^14.0.16",
 				"prettier": "^3.9.4",
 				"ts-jest": "^29.4.11",
@@ -223,9 +223,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+			"integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -390,13 +390,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+			"integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.28.6"
+				"@babel/helper-plugin-utils": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -516,13 +516,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-			"integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+			"integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.28.6"
+				"@babel/helper-plugin-utils": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1143,9 +1143,9 @@
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1219,61 +1219,61 @@
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
-			"integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+			"integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"chalk": "^4.1.2",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/core": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
-			"integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+			"integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/reporters": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/console": "30.4.1",
+				"@jest/pattern": "30.4.0",
+				"@jest/reporters": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-changed-files": "^29.7.0",
-				"jest-config": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-resolve-dependencies": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"strip-ansi": "^6.0.0"
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"exit-x": "^0.2.2",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-changed-files": "30.4.1",
+				"jest-config": "30.4.2",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-resolve-dependencies": "30.4.2",
+				"jest-runner": "30.4.2",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -1284,117 +1284,150 @@
 				}
 			}
 		},
+		"node_modules/@jest/diff-sequences": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+			"integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
 		"node_modules/@jest/environment": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+			"integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-mock": "^29.7.0"
+				"jest-mock": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"expect": "^29.7.0",
-				"jest-snapshot": "^29.7.0"
+				"expect": "30.4.1",
+				"jest-snapshot": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/expect-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
-			"integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+			"integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"jest-get-type": "^29.6.3"
+				"@jest/get-type": "30.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/fake-timers": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+			"integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@sinonjs/fake-timers": "^10.0.2",
+				"@jest/types": "30.4.1",
+				"@sinonjs/fake-timers": "^15.4.0",
 				"@types/node": "*",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/get-type": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+			"integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/globals": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
-			"integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+			"integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/types": "30.4.1",
+				"jest-mock": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
-			"integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+			"integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
+				"@jest/console": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"exit": "^0.1.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
+				"chalk": "^4.1.2",
+				"collect-v8-coverage": "^1.0.2",
+				"exit-x": "^0.2.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
 				"istanbul-lib-coverage": "^3.0.0",
 				"istanbul-lib-instrument": "^6.0.0",
 				"istanbul-lib-report": "^3.0.0",
-				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-lib-source-maps": "^5.0.0",
 				"istanbul-reports": "^3.1.3",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
 				"slash": "^3.0.0",
-				"string-length": "^4.0.1",
-				"strip-ansi": "^6.0.0",
+				"string-length": "^4.0.2",
 				"v8-to-istanbul": "^9.0.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -1406,108 +1439,124 @@
 			}
 		},
 		"node_modules/@jest/schemas": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-			"integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sinclair/typebox": "^0.27.8"
+				"@sinclair/typebox": "^0.34.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/snapshot-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+			"integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/source-map": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
-			"integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+			"integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"callsites": "^3.0.0",
-				"graceful-fs": "^4.2.9"
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"callsites": "^3.1.0",
+				"graceful-fs": "^4.2.11"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/test-result": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
-			"integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+			"integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"collect-v8-coverage": "^1.0.0"
+				"@jest/console": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"collect-v8-coverage": "^1.0.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/test-sequencer": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
-			"integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+			"integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
+				"@jest/test-result": "30.4.1",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+			"integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"babel-plugin-istanbul": "^6.1.1",
-				"chalk": "^4.0.0",
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.1",
+				"chalk": "^4.1.2",
 				"convert-source-map": "^2.0.0",
 				"fast-json-stable-stringify": "^2.1.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pirates": "^4.0.4",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"pirates": "^4.0.7",
 				"slash": "^3.0.0",
-				"write-file-atomic": "^4.0.2"
+				"write-file-atomic": "^5.0.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/types": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-			"integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^3.0.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
 				"@types/node": "*",
-				"@types/yargs": "^17.0.8",
-				"chalk": "^4.0.0"
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -3242,6 +3291,30 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@pkgr/core": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+			"integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/pkgr"
+			}
+		},
 		"node_modules/@playwright/test": {
 			"version": "1.61.1",
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
@@ -3260,9 +3333,9 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3277,13 +3350,13 @@
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@sinonjs/commons": "^3.0.0"
+				"@sinonjs/commons": "^3.0.1"
 			}
 		},
 		"node_modules/@standard-schema/spec": {
@@ -3456,16 +3529,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/graceful-fs": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-			"integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3494,14 +3557,14 @@
 			}
 		},
 		"node_modules/@types/jest": {
-			"version": "29.5.14",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-			"integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+			"version": "30.0.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+			"integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"expect": "^29.0.0",
-				"pretty-format": "^29.0.0"
+				"expect": "^30.0.0",
+				"pretty-format": "^30.0.0"
 			}
 		},
 		"node_modules/@types/json-schema": {
@@ -3854,6 +3917,13 @@
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
+			"integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
 			"version": "1.11.1",
@@ -4444,85 +4514,58 @@
 			}
 		},
 		"node_modules/babel-jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+			"integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/transform": "^29.7.0",
-				"@types/babel__core": "^7.1.14",
-				"babel-plugin-istanbul": "^6.1.1",
-				"babel-preset-jest": "^29.6.3",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
+				"@jest/transform": "30.4.1",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.1",
+				"babel-preset-jest": "30.4.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
 				"slash": "^3.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.8.0"
+				"@babel/core": "^7.11.0 || ^8.0.0-0"
 			}
 		},
 		"node_modules/babel-plugin-istanbul": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"workspaces": [
+				"test/babel-8"
+			],
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-instrument": "^5.0.4",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
 				"test-exclude": "^6.0.0"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-			"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@babel/parser": "^7.14.7",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-coverage": "^3.2.0",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/babel-plugin-istanbul/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver.js"
+				"node": ">=12"
 			}
 		},
 		"node_modules/babel-plugin-jest-hoist": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+			"integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.3.3",
-				"@babel/types": "^7.3.3",
-				"@types/babel__core": "^7.1.14",
-				"@types/babel__traverse": "^7.0.6"
+				"@types/babel__core": "^7.20.5"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/babel-preset-current-node-syntax": {
@@ -4553,20 +4596,20 @@
 			}
 		},
 		"node_modules/babel-preset-jest": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+			"integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"babel-plugin-jest-hoist": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0"
+				"babel-plugin-jest-hoist": "30.4.0",
+				"babel-preset-current-node-syntax": "^1.2.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
-				"@babel/core": "^7.0.0"
+				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
 			}
 		},
 		"node_modules/bach": {
@@ -4975,9 +5018,9 @@
 			}
 		},
 		"node_modules/ci-info": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
 			"funding": [
 				{
@@ -4991,9 +5034,9 @@
 			}
 		},
 		"node_modules/cjs-module-lexer": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-			"integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5141,28 +5184,6 @@
 				"node": ">= 10.13.0"
 			}
 		},
-		"node_modules/create-jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
-			"integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.2.9",
-				"jest-config": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"prompts": "^2.0.1"
-			},
-			"bin": {
-				"create-jest": "bin/create-jest.js"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5216,9 +5237,9 @@
 			}
 		},
 		"node_modules/dedent": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-			"integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -5308,16 +5329,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/diff-sequences": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-			"integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/dotenv": {
@@ -5874,11 +5885,12 @@
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
-		"node_modules/exit": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-			"integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+		"node_modules/exit-x": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+			"integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -5897,20 +5909,21 @@
 			}
 		},
 		"node_modules/expect": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
-			"integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/expect-utils": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"@jest/expect-utils": "30.4.1",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/extend": {
@@ -6444,22 +6457,22 @@
 			}
 		},
 		"node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
 			},
-			"engines": {
-				"node": "*"
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
@@ -6512,28 +6525,44 @@
 				"node": ">= 10.13.0"
 			}
 		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+		"node_modules/glob/node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
 			"dev": true,
-			"license": "MIT",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+		"node_modules/glob/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"dev": true,
-			"license": "ISC",
+			"license": "ISC"
+		},
+		"node_modules/glob/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/global-modules": {
@@ -7508,15 +7537,15 @@
 			}
 		},
 		"node_modules/istanbul-lib-source-maps": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-			"integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
 				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^3.0.0",
-				"source-map": "^0.6.1"
+				"istanbul-lib-coverage": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=10"
@@ -7578,22 +7607,22 @@
 			"license": "ISC"
 		},
 		"node_modules/jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+			"integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"import-local": "^3.0.2",
-				"jest-cli": "^29.7.0"
+				"@jest/core": "30.4.2",
+				"@jest/types": "30.4.1",
+				"import-local": "^3.2.0",
+				"jest-cli": "30.4.2"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -7605,76 +7634,75 @@
 			}
 		},
 		"node_modules/jest-changed-files": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
-			"integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+			"integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"execa": "^5.0.0",
-				"jest-util": "^29.7.0",
+				"execa": "^5.1.1",
+				"jest-util": "30.4.1",
 				"p-limit": "^3.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-circus": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
-			"integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+			"integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
+				"chalk": "^4.1.2",
 				"co": "^4.6.0",
-				"dedent": "^1.0.0",
-				"is-generator-fn": "^2.0.0",
-				"jest-each": "^29.7.0",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"dedent": "^1.6.0",
+				"is-generator-fn": "^2.1.0",
+				"jest-each": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
 				"p-limit": "^3.1.0",
-				"pretty-format": "^29.7.0",
-				"pure-rand": "^6.0.0",
+				"pretty-format": "30.4.1",
+				"pure-rand": "^7.0.0",
 				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
+				"stack-utils": "^2.0.6"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-cli": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
-			"integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+			"integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"create-jest": "^29.7.0",
-				"exit": "^0.1.2",
-				"import-local": "^3.0.2",
-				"jest-config": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"yargs": "^17.3.1"
+				"@jest/core": "30.4.2",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"exit-x": "^0.2.2",
+				"import-local": "^3.2.0",
+				"jest-config": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"yargs": "^17.7.2"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
@@ -7701,9 +7729,9 @@
 			}
 		},
 		"node_modules/jest-cli/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7720,44 +7748,49 @@
 			}
 		},
 		"node_modules/jest-config": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
-			"integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+			"integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/test-sequencer": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-jest": "^29.7.0",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"deepmerge": "^4.2.2",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-circus": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-runner": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"micromatch": "^4.0.4",
+				"@babel/core": "^7.27.4",
+				"@jest/get-type": "30.1.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/test-sequencer": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-jest": "30.4.1",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"deepmerge": "^4.3.1",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-circus": "30.4.2",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-runner": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
 				"parse-json": "^5.2.0",
-				"pretty-format": "^29.7.0",
+				"pretty-format": "30.4.1",
 				"slash": "^3.0.0",
 				"strip-json-comments": "^3.1.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"@types/node": "*",
+				"esbuild-register": ">=3.4.0",
 				"ts-node": ">=9.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/node": {
+					"optional": true
+				},
+				"esbuild-register": {
 					"optional": true
 				},
 				"ts-node": {
@@ -7766,169 +7799,186 @@
 			}
 		},
 		"node_modules/jest-diff": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-			"integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+			"integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^4.0.0",
-				"diff-sequences": "^29.6.3",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
+				"@jest/diff-sequences": "30.4.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-docblock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
-			"integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+			"integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"detect-newline": "^3.0.0"
+				"detect-newline": "^3.1.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-each": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
-			"integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+			"integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"pretty-format": "^29.7.0"
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+			"integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-get-type": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-haste-map": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+			"integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/graceful-fs": "^4.1.3",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"anymatch": "^3.0.3",
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"micromatch": "^4.0.4",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"picomatch": "^4.0.3",
 				"walker": "^1.0.8"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			},
 			"optionalDependencies": {
-				"fsevents": "^2.3.2"
+				"fsevents": "^2.3.3"
+			}
+		},
+		"node_modules/jest-haste-map/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-leak-detector": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
-			"integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+			"integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
+				"@jest/get-type": "30.1.0",
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-matcher-utils": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
-			"integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+			"integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^4.0.0",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"pretty-format": "^29.7.0"
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.4.1",
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+			"integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.4.1",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-util": "30.4.1",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.4.1",
 				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
+				"stack-utils": "^2.0.6"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+			"integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"jest-util": "^29.7.0"
+				"jest-util": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-pnp-resolver": {
@@ -7950,183 +8000,197 @@
 			}
 		},
 		"node_modules/jest-regex-util": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-resolve": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
-			"integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+			"integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^29.7.0",
-				"jest-validate": "^29.7.0",
-				"resolve": "^1.20.0",
-				"resolve.exports": "^2.0.0",
-				"slash": "^3.0.0"
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-pnp-resolver": "^1.2.3",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"slash": "^3.0.0",
+				"unrs-resolver": "^1.7.11"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-resolve-dependencies": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
-			"integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+			"integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"jest-regex-util": "^29.6.3",
-				"jest-snapshot": "^29.7.0"
+				"jest-regex-util": "30.4.0",
+				"jest-snapshot": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-runner": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
-			"integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+			"integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "^29.7.0",
-				"@jest/environment": "^29.7.0",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/console": "30.4.1",
+				"@jest/environment": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
+				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"graceful-fs": "^4.2.9",
-				"jest-docblock": "^29.7.0",
-				"jest-environment-node": "^29.7.0",
-				"jest-haste-map": "^29.7.0",
-				"jest-leak-detector": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-resolve": "^29.7.0",
-				"jest-runtime": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"jest-watcher": "^29.7.0",
-				"jest-worker": "^29.7.0",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-haste-map": "30.4.1",
+				"jest-leak-detector": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-resolve": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"jest-worker": "30.4.1",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-runtime": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
-			"integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+			"integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/globals": "^29.7.0",
-				"@jest/source-map": "^29.6.3",
-				"@jest/test-result": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/globals": "30.4.1",
+				"@jest/source-map": "30.0.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"cjs-module-lexer": "^1.0.0",
-				"collect-v8-coverage": "^1.0.0",
-				"glob": "^7.1.3",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-resolve": "^29.7.0",
-				"jest-snapshot": "^29.7.0",
-				"jest-util": "^29.7.0",
+				"chalk": "^4.1.2",
+				"cjs-module-lexer": "^2.1.0",
+				"collect-v8-coverage": "^1.0.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-snapshot": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
-			"integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+			"integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@babel/generator": "^7.7.2",
-				"@babel/plugin-syntax-jsx": "^7.7.2",
-				"@babel/plugin-syntax-typescript": "^7.7.2",
-				"@babel/types": "^7.3.3",
-				"@jest/expect-utils": "^29.7.0",
-				"@jest/transform": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0",
-				"chalk": "^4.0.0",
-				"expect": "^29.7.0",
-				"graceful-fs": "^4.2.9",
-				"jest-diff": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^29.7.0",
-				"semver": "^7.5.3"
+				"@babel/core": "^7.27.4",
+				"@babel/generator": "^7.27.5",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-syntax-typescript": "^7.27.1",
+				"@babel/types": "^7.27.3",
+				"@jest/expect-utils": "30.4.1",
+				"@jest/get-type": "30.1.0",
+				"@jest/snapshot-utils": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-preset-current-node-syntax": "^1.2.0",
+				"chalk": "^4.1.2",
+				"expect": "30.4.1",
+				"graceful-fs": "^4.2.11",
+				"jest-diff": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1",
+				"semver": "^7.7.2",
+				"synckit": "^0.11.8"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-			"integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"chalk": "^4.0.0",
-				"ci-info": "^3.2.0",
-				"graceful-fs": "^4.2.9",
-				"picomatch": "^2.2.3"
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/jest-validate": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-			"integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+			"integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"camelcase": "^6.2.0",
-				"chalk": "^4.0.0",
-				"jest-get-type": "^29.6.3",
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"camelcase": "^6.3.0",
+				"chalk": "^4.1.2",
 				"leven": "^3.1.0",
-				"pretty-format": "^29.7.0"
+				"pretty-format": "30.4.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-validate/node_modules/camelcase": {
@@ -8143,39 +8207,40 @@
 			}
 		},
 		"node_modules/jest-watcher": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
-			"integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+			"integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "^29.7.0",
-				"@jest/types": "^29.6.3",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
 				"@types/node": "*",
-				"ansi-escapes": "^4.2.1",
-				"chalk": "^4.0.0",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
 				"emittery": "^0.13.1",
-				"jest-util": "^29.7.0",
-				"string-length": "^4.0.1"
+				"jest-util": "30.4.1",
+				"string-length": "^4.0.2"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-worker": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-			"integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+			"integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
-				"jest-util": "^29.7.0",
+				"@ungap/structured-clone": "^1.3.0",
+				"jest-util": "30.4.1",
 				"merge-stream": "^2.0.0",
-				"supports-color": "^8.0.0"
+				"supports-color": "^8.1.1"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jmespath": {
@@ -9779,18 +9844,19 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-			"integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+			"integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/schemas": "^29.6.3",
-				"ansi-styles": "^5.0.0",
-				"react-is": "^18.0.0"
+				"@jest/schemas": "30.4.1",
+				"ansi-styles": "^5.2.0",
+				"react-is-18": "npm:react-is@^18.3.1",
+				"react-is-19": "npm:react-is@^19.2.5"
 			},
 			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/pretty-format/node_modules/ansi-styles": {
@@ -9862,9 +9928,9 @@
 			}
 		},
 		"node_modules/pure-rand": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
-			"integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -9907,10 +9973,19 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/react-is": {
+		"node_modules/react-is-18": {
+			"name": "react-is",
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
 			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/react-is-19": {
+			"name": "react-is",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+			"integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10123,16 +10198,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-			}
-		},
-		"node_modules/resolve.exports": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
-			"integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/retry-axios": {
@@ -10710,6 +10775,22 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/synckit": {
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+			"integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pkgr/core": "^0.3.6"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/synckit"
+			}
+		},
 		"node_modules/teex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
@@ -10744,6 +10825,28 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/test-exclude/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/test-exclude/node_modules/minimatch": {
@@ -11645,17 +11748,30 @@
 			"license": "ISC"
 		},
 		"node_modules/write-file-atomic": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.7"
+				"signal-exit": "^4.0.1"
 			},
 			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/write-file-atomic/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.6.10",
 			"license": "MIT",
 			"devDependencies": {
-				"@n8n/node-cli": "*",
+				"@n8n/node-cli": "^0.37.2",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^24.0.1",
 				"eslint": "^9.32.0",
@@ -24,7 +24,7 @@
 				"node": ">=22.0.0"
 			},
 			"peerDependencies": {
-				"n8n-workflow": "^1.120.14"
+				"n8n-workflow": "*"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {
@@ -599,9 +599,9 @@
 			}
 		},
 		"node_modules/@browserbasehq/sdk": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.12.0.tgz",
-			"integrity": "sha512-bwgVjjYc4O54Cvkc5POfZUv0Gl92n1nNfAPueRLQVFsDoPRTw0FS8wKo9/bQCQuyzAg9+RQUDqvUC241ogLRTQ==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.14.1.tgz",
+			"integrity": "sha512-Ahmzb5+82ePgSGwouKEoAhiGy8mJ3RbCl+uigfGfVc60zseYIftcMiDPXSmrTQr1NHaATRx4cJlynP8ZUweXtg==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -955,49 +955,6 @@
 				"node": ">=18.18.0"
 			}
 		},
-		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-			"deprecated": "Use @eslint/config-array instead",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.3",
-				"debug": "^4.3.1",
-				"minimatch": "^3.0.5"
-			},
-			"engines": {
-				"node": ">=10.10.0"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/@humanwhocodes/module-importer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -1011,15 +968,6 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
 			}
-		},
-		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-			"deprecated": "Use @eslint/object-schema instead",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
 		},
 		"node_modules/@humanwhocodes/retry": {
 			"version": "0.4.3",
@@ -1036,15 +984,15 @@
 			}
 		},
 		"node_modules/@ibm-cloud/watsonx-ai": {
-			"version": "1.7.13",
-			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.13.tgz",
-			"integrity": "sha512-xduIj2subUermAwmz3mz5LXlLfUVyN+NwzswsIkl5EmU4t4VJ/040gtdbsjmwWrwKBA6xPxTt3i1NAEaFVvahA==",
+			"version": "1.7.14",
+			"resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.14.tgz",
+			"integrity": "sha512-nP0ayzuck6gDpL5ohkI7t3ExXPfF0TICyO/QroGbW7lKd996Rzzls1+X9gZE3B6xQLbCJz9/AsM+YhE+dcnY5g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"form-data": "^4.0.4",
-				"ibm-cloud-sdk-core": "^5.4.14"
+				"ibm-cloud-sdk-core": "^5.4.20"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -1672,19 +1620,28 @@
 			}
 		},
 		"node_modules/@langchain/classic/node_modules/openai": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-			"integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
+			"version": "6.45.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+			"integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+				"@smithy/hash-node": ">=4.3.0 <5",
+				"@smithy/signature-v4": ">=5.4.0 <6",
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
 			},
 			"peerDependenciesMeta": {
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@smithy/hash-node": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
 				"ws": {
 					"optional": true
 				},
@@ -1704,9 +1661,9 @@
 			}
 		},
 		"node_modules/@langchain/core": {
-			"version": "1.1.48",
-			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.48.tgz",
-			"integrity": "sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-NNG/cC5FGuHDOAP56h0ddp8Rfk8p+othWzEK5RV9JIG6RvnF5vGa5r0AEGtKfQieed7s1kC42GuIzVOBvMBL/g==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1735,63 +1692,52 @@
 			}
 		},
 		"node_modules/@langchain/langgraph": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.3.2.tgz",
-			"integrity": "sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==",
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.7.tgz",
+			"integrity": "sha512-2tcyf3QGC7v89kqSxMCtRvzg/3L/4yHtOaWC49A8KieCciWJs7LGaxHoPB6QRxXyUgyR+Zg9Q1ss/XJIE+JuSQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@langchain/langgraph-checkpoint": "^1.0.2",
-				"@langchain/langgraph-sdk": "~1.9.4",
-				"@langchain/protocol": "^0.0.15",
-				"@standard-schema/spec": "1.1.0",
-				"uuid": "^10.0.0"
+				"@langchain/langgraph-checkpoint": "^1.1.3",
+				"@langchain/langgraph-sdk": "~1.9.25",
+				"@langchain/protocol": "^0.0.18",
+				"@standard-schema/spec": "1.1.0"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@langchain/core": "^1.1.44",
-				"zod": "^3.25.32 || ^4.2.0",
-				"zod-to-json-schema": "^3.x"
-			},
-			"peerDependenciesMeta": {
-				"zod-to-json-schema": {
-					"optional": true
-				}
+				"@langchain/core": "^1.1.48",
+				"zod": "^3.25.32 || ^4.2.0"
 			}
 		},
 		"node_modules/@langchain/langgraph-checkpoint": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
-			"integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
+			"integrity": "sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"uuid": "^10.0.0"
-			},
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@langchain/core": "^1.1.44"
+				"@langchain/core": "^1.1.48"
 			}
 		},
 		"node_modules/@langchain/langgraph-sdk": {
-			"version": "1.9.9",
-			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.9.tgz",
-			"integrity": "sha512-aiWHbmqxWj5sAMwFsaB3eSGQvKpMbUKTlt9zbAC0T7IiFqDYUWi9gJUGsTdvJutAfB3P/NzC4s8ETUtUQEUlYg==",
+			"version": "1.9.25",
+			"resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.25.tgz",
+			"integrity": "sha512-mRKW8zyQUaHox+HirRFMRrPqOvNbQI3xeXDt6kkk4PbBg77V92bsO1WzUVNrmJ81zCkvxyOrWSK8D6ioCj0a8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@langchain/protocol": "^0.0.15",
+				"@langchain/protocol": "^0.0.18",
 				"@types/json-schema": "^7.0.15",
 				"p-queue": "^9.0.1",
-				"p-retry": "^7.1.1",
-				"uuid": "^13.0.0"
+				"p-retry": "^7.1.1"
 			},
 			"peerDependencies": {
-				"@langchain/core": "^1.1.44",
+				"@langchain/core": "^1.1.48",
 				"react": "^18 || ^19",
 				"react-dom": "^18 || ^19",
 				"svelte": "^4.0.0 || ^5.0.0",
@@ -1849,20 +1795,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@langchain/langgraph-sdk/node_modules/uuid": {
-			"version": "13.0.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
-			"integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"node_modules/@langchain/openai": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-1.4.4.tgz",
@@ -1882,19 +1814,28 @@
 			}
 		},
 		"node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-			"integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
+			"version": "6.45.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+			"integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+				"@smithy/hash-node": ">=4.3.0 <5",
+				"@smithy/signature-v4": ">=5.4.0 <6",
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
 			},
 			"peerDependenciesMeta": {
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@smithy/hash-node": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
 				"ws": {
 					"optional": true
 				},
@@ -1914,9 +1855,9 @@
 			}
 		},
 		"node_modules/@langchain/protocol": {
-			"version": "0.0.15",
-			"resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.15.tgz",
-			"integrity": "sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==",
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.18.tgz",
+			"integrity": "sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1954,30 +1895,20 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@n8n_io/riot-tmpl": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@n8n_io/riot-tmpl/-/riot-tmpl-4.0.1.tgz",
-			"integrity": "sha512-/zdRbEfTFjsm1NqnpPQHgZTkTdbp5v3VUxGeMA9098sps8jRCTraQkc3AQstJgHUm7ylBXJcIVhnVeLUMWAfwQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"eslint-config-riot": "^1.0.0"
-			}
-		},
 		"node_modules/@n8n/ai-node-sdk": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.12.1.tgz",
-			"integrity": "sha512-VnLNC0p/yNyxdSu11ClZg/7Dp6R1r53NEIBTBFGVBLgiEYQO8nckUKLmjIPsel4NuHgvwxSIVoLrN21lE7zzZA==",
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.18.2.tgz",
+			"integrity": "sha512-44HUwBotjEbmLFiTtwLzx+pWsLqnvlcXh9CZERZb8NW7KAdWR4W7vC3w0Doj52VZka89uV46t9YdTq/tmdn6+w==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n/ai-utilities": "0.15.1"
+				"@n8n/ai-utilities": "0.21.2"
 			}
 		},
 		"node_modules/@n8n/ai-utilities": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.15.1.tgz",
-			"integrity": "sha512-zdojN4lTI5z+wU/nlsKmssdJ3AeqeRzqATiHekFmeXgLbbDo2Vp48OQJZhqJyHJyGiju0wxEXAFIL1dF0O2RBg==",
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.21.2.tgz",
+			"integrity": "sha512-Kx+EfA1DvCsGyvDR2ucwvtTOSRHXlE7yaHBtEDyiTKx5kMuEJv9JuF4Y8tLKmh3f4g/norNWqmyTJEVAHZMNag==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -1986,19 +1917,21 @@
 				"@langchain/core": "1.1.41",
 				"@langchain/openai": "1.4.4",
 				"@langchain/textsplitters": "1.0.1",
-				"@n8n/config": "2.20.0",
-				"@n8n/typescript-config": "1.4.0",
+				"@n8n/config": "2.26.0",
+				"@n8n/typescript-config": "1.6.1",
+				"@n8n/utils": "1.36.0",
+				"@thednp/dommatrix": "^2.0.12",
 				"https-proxy-agent": "7.0.6",
 				"js-tiktoken": "1.0.21",
 				"langchain": "1.2.30",
+				"lodash": "4.18.1",
+				"n8n-workflow": "2.28.2",
+				"pdf-parse": "2.4.5",
 				"proxy-from-env": "^1.1.0",
 				"tmp-promise": "3.0.3",
-				"undici": "^6.21.0",
+				"undici": "^6.24.0",
 				"zod": "3.25.67",
 				"zod-to-json-schema": "3.23.3"
-			},
-			"peerDependencies": {
-				"n8n-workflow": "*"
 			}
 		},
 		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community": {
@@ -2515,19 +2448,28 @@
 			}
 		},
 		"node_modules/@n8n/ai-utilities/node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
-			"version": "6.39.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-6.39.0.tgz",
-			"integrity": "sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==",
+			"version": "6.45.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+			"integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"bin": {
-				"openai": "bin/cli"
-			},
 			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+				"@smithy/hash-node": ">=4.3.0 <5",
+				"@smithy/signature-v4": ">=5.4.0 <6",
 				"ws": "^8.18.0",
 				"zod": "^3.25 || ^4.0"
 			},
 			"peerDependenciesMeta": {
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@smithy/hash-node": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
 				"ws": {
 					"optional": true
 				},
@@ -2619,22 +2561,42 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@n8n/ai-utilities/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/@n8n/config": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.20.0.tgz",
-			"integrity": "sha512-5sl2z8DRhjr6E/clW+r8xw9zE0IGXz8/TXNsiunxrc2TPHV/YPEL/jH70Ly+tbxMYqf5WtTtHuPeXOi2XY4RTw==",
+			"version": "2.26.0",
+			"resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.26.0.tgz",
+			"integrity": "sha512-DvCL2Ag9wx5l6x4F1CirfEEd2c6DUZAwTwnBwgjiyVfKI0/pxVtsdqL5BNYGHWW9DKHXPjQeqFH48FEoC5uPYg==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n/di": "0.11.0",
+				"@n8n/constants": "0.28.0",
+				"@n8n/di": "0.14.0",
 				"reflect-metadata": "0.2.2",
 				"zod": "3.25.67"
 			}
 		},
+		"node_modules/@n8n/constants": {
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.28.0.tgz",
+			"integrity": "sha512-LXKD91ms2qDQkGAOc4MAuphhh1HOjGuzQe6WPS6Ul9eu92/0iSyyoHUzymfcmUb3/Q9959T0nXgOkzKiyHedLQ==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md"
+		},
 		"node_modules/@n8n/di": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.11.0.tgz",
-			"integrity": "sha512-6WHrIulFRD5KPAlVYQ1rPYzUKkbw856VEdzq03lmbOKUZpcuxr/wBSprUmbj//KCDsSK2lE0GZ/wSW03iV8YyQ==",
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.14.0.tgz",
+			"integrity": "sha512-n72LSevYQIvN9DYWvkskHslsJbw/X4/OL5IN48Gb+3dOIcAHZYnOwIZPllLMKz/9WaVk54kEGwLsyrYb7LkHEw==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
@@ -2642,68 +2604,51 @@
 			}
 		},
 		"node_modules/@n8n/errors": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.5.0.tgz",
-			"integrity": "sha512-0Vk1Eb3Uor+zeF/WVnuhFgJc51wEBTZNBlVQy3mvyr3sGmW86bP1jA7wmRsd0DZbswPwN0vNOl/TmkDTEopOtQ==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.10.0.tgz",
+			"integrity": "sha512-Qle4gCsx7qtDRMdie3YkjuXPuo369PP32cR9Svb+INwcjLMxNzmnbJ66jFnOmLn0ntwBccUw1IecJ6axwyTgBQ==",
 			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
 			"dependencies": {
 				"callsites": "3.1.0"
 			}
 		},
 		"node_modules/@n8n/expression-runtime": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.8.0.tgz",
-			"integrity": "sha512-SnBLoLsrGUCS9cVrF20UuSyKcMv+y6Clc4+EA9zLjX85S0GPwOAdApUVSsi81ejPAqMlm42TW1L6r7NpcK/ztQ==",
-			"dev": true,
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.19.0.tgz",
+			"integrity": "sha512-ShRp3TEue2dNaP/PIQzD5DqyYUjkiaIsDVwsyfAvhsdyIUKyishsHsnogv527vjuA/WzH5cYn9X75lFeQA8hZg==",
 			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
 			"dependencies": {
-				"@n8n/tournament": "1.0.6",
-				"isolated-vm": "^6.0.2",
-				"js-base64": "3.7.2",
+				"@n8n/errors": "0.10.0",
+				"@n8n/tournament": "1.4.0",
+				"isolated-vm": "^6.1.2",
+				"jmespath": "0.16.0",
+				"js-base64": "3.7.8",
 				"jssha": "3.3.1",
-				"lodash": "4.17.23",
+				"lodash": "4.18.1",
 				"luxon": "3.7.2",
 				"md5": "2.3.0",
 				"title-case": "3.0.3",
-				"transliteration": "2.3.5"
-			}
-		},
-		"node_modules/@n8n/expression-runtime/node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@n8n/expression-runtime/node_modules/luxon": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-			"integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
+				"transliteration": "2.3.5",
+				"zod": "3.25.67"
 			}
 		},
 		"node_modules/@n8n/node-cli": {
-			"version": "0.31.1",
-			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.31.1.tgz",
-			"integrity": "sha512-DQau8xpY1s8PtrHxvkpwA9p0ziN0EttF9YtGij2xpIPyOWMm2bAkhtyXBlrwkJR2npFKh41un8cGdK4rogop8Q==",
+			"version": "0.37.2",
+			"resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.37.2.tgz",
+			"integrity": "sha512-y4H6N4c7oM1ZuLzOdfylSKpxIRM6E2NaalOlbDIgnyWb8Z3Y9csT5Sq1grAOAuryinNhCX4RxFt/xfGMWhcC4w==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
 				"@clack/prompts": "^0.11.0",
-				"@n8n/ai-node-sdk": "0.12.1",
-				"@n8n/eslint-plugin-community-nodes": "0.16.0",
+				"@eslint/js": "^9.29.0",
+				"@n8n/ai-node-sdk": "0.18.2",
+				"@n8n/eslint-plugin-community-nodes": "0.22.0",
 				"@oclif/core": "^4.5.2",
 				"change-case": "^5.4.4",
+				"eslint": "9.29.0",
 				"eslint-import-resolver-typescript": "^4.4.3",
 				"eslint-plugin-import-x": "^4.15.2",
-				"eslint-plugin-n8n-nodes-base": "1.16.5",
+				"eslint-plugin-n8n-nodes-base": "1.16.7",
 				"fast-glob": "3.2.12",
 				"handlebars": "4.7.9",
 				"picocolors": "1.0.1",
@@ -2717,100 +2662,199 @@
 				"n8n-node": "bin/n8n-node.mjs"
 			},
 			"peerDependencies": {
-				"eslint": ">= 9"
+				"eslint": "9.29.0"
 			}
 		},
-		"node_modules/@n8n/node-cli/node_modules/@n8n/errors": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.6.0.tgz",
-			"integrity": "sha512-oVJ0lgRYJY6/aPOW2h37ea5T+nX7/wULRn5FymwYeaiYlsLdqwIQEtGwZrajpzxJB0Os74u4lSH3WWQgZCkgxQ==",
+		"node_modules/@n8n/node-cli/node_modules/@eslint/config-array": {
+			"version": "0.20.1",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
+			"integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
 			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"callsites": "3.1.0"
+				"@eslint/object-schema": "^2.1.6",
+				"debug": "^4.3.1",
+				"minimatch": "^3.1.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@n8n/node-cli/node_modules/@eslint/config-helpers": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
+			"integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@n8n/node-cli/node_modules/@eslint/core": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+			"integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@n8n/node-cli/node_modules/@eslint/js": {
+			"version": "9.29.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+			"integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			}
+		},
+		"node_modules/@n8n/node-cli/node_modules/@eslint/plugin-kit": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.15.2",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@n8n/node-cli/node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@n8n/node-cli/node_modules/@n8n/eslint-plugin-community-nodes": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.16.0.tgz",
-			"integrity": "sha512-XHrHQuOqbo9vAuHhSnvLZkHWzTFgS8Baou6E3qBhctu2JKamS+SSENUe69c7Fa/QUAUG29ufN3DigLutoa0Esg==",
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.22.0.tgz",
+			"integrity": "sha512-83+NrTPr9mB+Lgo3YAhTFILC8h5yQAXVQdaC3pUTF72dAG+VA7TGqnd+oLW+IOD8M5B7UYYxyXbBJlvBHWQFKA==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
+				"@typescript-eslint/typescript-estree": "^8.35.0",
 				"@typescript-eslint/utils": "^8.35.0",
 				"fastest-levenshtein": "1.0.16"
 			},
 			"peerDependencies": {
-				"eslint": ">= 9",
+				"eslint": "9.29.0",
 				"n8n-workflow": ">=2"
 			}
 		},
-		"node_modules/@n8n/node-cli/node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+		"node_modules/@n8n/node-cli/node_modules/brace-expansion": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@n8n/node-cli/node_modules/eslint": {
+			"version": "9.29.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
+			"integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.2.0",
+				"@eslint-community/regexpp": "^4.12.1",
+				"@eslint/config-array": "^0.20.1",
+				"@eslint/config-helpers": "^0.2.1",
+				"@eslint/core": "^0.14.0",
+				"@eslint/eslintrc": "^3.3.1",
+				"@eslint/js": "9.29.0",
+				"@eslint/plugin-kit": "^0.3.1",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"@types/json-schema": "^7.0.15",
+				"ajv": "^6.12.4",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^8.4.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
+				"esquery": "^1.5.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.2",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@n8n/node-cli/node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+		"node_modules/@n8n/node-cli/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@n8n/node-cli/node_modules/luxon": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
-			"integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
+			"license": "Apache-2.0",
 			"engines": {
-				"node": ">=12"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@n8n/node-cli/node_modules/n8n-workflow": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.16.0.tgz",
-			"integrity": "sha512-JoDvHLvV4QZQBCDVQl5xkrGOmPmsacLO4TkJkErCzMmiEqIej+h14J6eCUY7gbxBj8V+GIBlpqyO63akJbXRQg==",
+		"node_modules/@n8n/node-cli/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
+			"license": "ISC",
 			"dependencies": {
-				"@n8n/errors": "0.6.0",
-				"@n8n/expression-runtime": "0.8.0",
-				"@n8n/tournament": "1.0.6",
-				"ast-types": "0.16.1",
-				"callsites": "3.1.0",
-				"esprima-next": "5.8.4",
-				"form-data": "4.0.4",
-				"jmespath": "0.16.0",
-				"js-base64": "3.7.2",
-				"jsonrepair": "3.13.2",
-				"jssha": "3.3.1",
-				"lodash": "4.17.23",
-				"luxon": "3.7.2",
-				"md5": "2.3.0",
-				"recast": "0.22.0",
-				"title-case": "3.0.3",
-				"transliteration": "2.3.5",
-				"uuid": "10.0.0",
-				"xml2js": "0.6.2",
-				"zod": "3.25.67"
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@n8n/node-cli/node_modules/prettier": {
@@ -2830,13 +2874,11 @@
 			}
 		},
 		"node_modules/@n8n/tournament": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.0.6.tgz",
-			"integrity": "sha512-UGSxYXXVuOX0yL6HTLBStKYwLIa0+JmRKiSZSCMcM2s2Wax984KWT6XIA1TR/27i7yYpDk1MY14KsTPnuEp27A==",
-			"license": "Apache-2.0",
-			"peer": true,
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.4.0.tgz",
+			"integrity": "sha512-llDdmIj3Kdfq2vX/NpLBOUU4kLjhITtIMeJmOSTApAOeAArj1D45ey4D7CFaYcYsPBw6DgF0vxifyskPDlgekw==",
+			"license": "SEE LICENSE IN LICENSE.md",
 			"dependencies": {
-				"@n8n_io/riot-tmpl": "^4.0.1",
 				"ast-types": "^0.16.1",
 				"esprima-next": "^5.8.4",
 				"recast": "^0.22.0"
@@ -2847,11 +2889,217 @@
 			}
 		},
 		"node_modules/@n8n/typescript-config": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.4.0.tgz",
-			"integrity": "sha512-HC2rgU/FtbOb6vpC/VvqfOxqeMkmQH/YdZK1y/wel7YgMCJcv92IhjJPehW1Qpp+OUesGTn03VJb4vee/ZEBkw==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@n8n/typescript-config/-/typescript-config-1.6.1.tgz",
+			"integrity": "sha512-/UFXl0C2XoNAUdF8/2C5v+vAKozH9R/wcJpdJDwmsYOFHHkcmDAVEitDPNMh6k5Pk+nBOQmAdAis1O0D/eOWUw==",
 			"dev": true,
 			"license": "SEE LICENSE IN LICENSE.md"
+		},
+		"node_modules/@n8n/utils": {
+			"version": "1.36.0",
+			"resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.36.0.tgz",
+			"integrity": "sha512-jCDMP//aOWunK3pw1W1bYwdCnpuRy7Tpr+dHYr5Y67bi5x4e9d+sVdIWz3c9JcMIL5pR3sSuEFb2AyUh3cGrtg==",
+			"dev": true,
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@n8n/constants": "0.28.0",
+				"nanoid": "3.3.8"
+			}
+		},
+		"node_modules/@napi-rs/canvas": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+			"integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"e2e/*"
+			],
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas-android-arm64": "0.1.80",
+				"@napi-rs/canvas-darwin-arm64": "0.1.80",
+				"@napi-rs/canvas-darwin-x64": "0.1.80",
+				"@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+				"@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+				"@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+				"@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+				"@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+				"@napi-rs/canvas-linux-x64-musl": "0.1.80",
+				"@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+			}
+		},
+		"node_modules/@napi-rs/canvas-android-arm64": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+			"integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-arm64": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+			"integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-darwin-x64": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+			"integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+			"integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+			"integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-arm64-musl": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+			"integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+			"integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-gnu": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+			"integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-linux-x64-musl": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+			"integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@napi-rs/canvas-win32-x64-msvc": {
+			"version": "0.1.80",
+			"resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+			"integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
@@ -2960,14 +3208,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.60.0"
+				"playwright": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -3009,6 +3257,17 @@
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@thednp/dommatrix": {
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@thednp/dommatrix/-/dommatrix-2.0.12.tgz",
+			"integrity": "sha512-eOshhlSShBXLfrMQqqhA450TppJXhKriaQdN43mmniOCMn9sD60QKF1Axsj7bKl339WH058LuGFS6H84njYH5w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20",
+				"pnpm": ">=8.6.0"
+			}
 		},
 		"node_modules/@tokenizer/inflate": {
 			"version": "0.4.1",
@@ -3246,13 +3505,6 @@
 				"@types/node": "*",
 				"form-data": "^4.0.4"
 			}
-		},
-		"node_modules/@types/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
@@ -3528,14 +3780,6 @@
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
-		},
-		"node_modules/@ungap/structured-clone": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true
 		},
 		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
 			"version": "1.11.1",
@@ -3975,22 +4219,11 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/assert": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
 			"integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"is-nan": "^1.3.2",
@@ -4004,7 +4237,6 @@
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
 			"integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.0.1"
 			},
@@ -4051,15 +4283,13 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
 			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
 			},
@@ -4071,9 +4301,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-			"integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+			"integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -4483,7 +4713,6 @@
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
 			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
@@ -4502,7 +4731,6 @@
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2"
@@ -4516,7 +4744,6 @@
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"get-intrinsic": "^1.3.0"
@@ -4631,7 +4858,6 @@
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -4796,7 +5022,6 @@
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"delayed-stream": "~1.0.0"
 			},
@@ -4884,7 +5109,6 @@
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -4954,7 +5178,6 @@
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -4972,7 +5195,6 @@
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
 			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
@@ -4990,7 +5212,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -5025,33 +5246,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/dir-glob": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-type": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/doctrine": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/dotenv": {
 			"version": "16.6.1",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -5071,7 +5265,6 @@
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
 				"es-errors": "^1.3.0",
@@ -5180,7 +5373,6 @@
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5190,7 +5382,6 @@
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5200,7 +5391,6 @@
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
 			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0"
 			},
@@ -5212,9 +5402,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
 			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"get-intrinsic": "^1.2.6",
@@ -5306,13 +5494,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/eslint-config-riot": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-riot/-/eslint-config-riot-1.0.0.tgz",
-			"integrity": "sha512-NB/L/1Y30qyJcG5xZxCJKW/+bqyj+llbcCwo9DEz8bESIP0SLTOQ8T1DWCCFc+wJ61AMEstj4511PSScqMMfCw==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/eslint-import-context": {
 			"version": "0.1.9",
@@ -5412,14 +5593,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-n8n-nodes-base": {
-			"version": "1.16.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n8n-nodes-base/-/eslint-plugin-n8n-nodes-base-1.16.5.tgz",
-			"integrity": "sha512-/Bx2xj1ZzwEN+KQmnf7i0QRzgNMuphythQI2qXHoJQd8nm6aJGC9ZyVmDBFkM9P1ZfVBgBK7bDdjNxcbIK8Hgw==",
+			"version": "1.16.7",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n8n-nodes-base/-/eslint-plugin-n8n-nodes-base-1.16.7.tgz",
+			"integrity": "sha512-lKo+stn4t2jXX/ZdmJv2ClUQnRZLwSOyqfqsYgD6I/wYwy9bqA6mna4CEzdQNFVg5f3/RODpd/JQMiITARY92g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/utils": "^6.21.0",
+				"@typescript-eslint/utils": "^8.35.0",
 				"camel-case": "^4.1.2",
 				"indefinite": "^2.5.1",
 				"pascal-case": "^3.1.2",
@@ -5430,400 +5611,6 @@
 			"engines": {
 				"node": ">=20.15",
 				"pnpm": ">=9.6"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/eslintrc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ajv": "^6.12.4",
-				"debug": "^4.3.2",
-				"espree": "^9.6.0",
-				"globals": "^13.19.0",
-				"ignore": "^5.2.0",
-				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
-				"minimatch": "^3.1.2",
-				"strip-json-comments": "^3.1.1"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@eslint/js": {
-			"version": "8.57.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-			"integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/types": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-			"integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-			"integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/visitor-keys": "6.21.0",
-				"debug": "^4.3.4",
-				"globby": "^11.1.0",
-				"is-glob": "^4.0.3",
-				"minimatch": "9.0.3",
-				"semver": "^7.5.4",
-				"ts-api-utils": "^1.0.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/utils": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-			"integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@types/json-schema": "^7.0.12",
-				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.21.0",
-				"@typescript-eslint/types": "6.21.0",
-				"@typescript-eslint/typescript-estree": "6.21.0",
-				"semver": "^7.5.4"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-			"integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@typescript-eslint/types": "6.21.0",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^16.0.0 || >=18.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint": {
-			"version": "8.57.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.2.0",
-				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.57.1",
-				"@humanwhocodes/config-array": "^0.13.0",
-				"@humanwhocodes/module-importer": "^1.0.1",
-				"@nodelib/fs.walk": "^1.2.8",
-				"@ungap/structured-clone": "^1.2.0",
-				"ajv": "^6.12.4",
-				"chalk": "^4.0.0",
-				"cross-spawn": "^7.0.2",
-				"debug": "^4.3.2",
-				"doctrine": "^3.0.0",
-				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.2.2",
-				"eslint-visitor-keys": "^3.4.3",
-				"espree": "^9.6.1",
-				"esquery": "^1.4.2",
-				"esutils": "^2.0.2",
-				"fast-deep-equal": "^3.1.3",
-				"file-entry-cache": "^6.0.1",
-				"find-up": "^5.0.0",
-				"glob-parent": "^6.0.2",
-				"globals": "^13.19.0",
-				"graphemer": "^1.4.0",
-				"ignore": "^5.2.0",
-				"imurmurhash": "^0.1.4",
-				"is-glob": "^4.0.0",
-				"is-path-inside": "^3.0.3",
-				"js-yaml": "^4.1.0",
-				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"levn": "^0.4.1",
-				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
-				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3",
-				"strip-ansi": "^6.0.1",
-				"text-table": "^0.2.0"
-			},
-			"bin": {
-				"eslint": "bin/eslint.js"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint-scope": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"esrecurse": "^4.3.0",
-				"estraverse": "^5.2.0"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/espree": {
-			"version": "9.6.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"acorn": "^8.9.0",
-				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.4.1"
-			},
-			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/file-entry-cache": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"flat-cache": "^3.0.4"
-			},
-			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/flat-cache": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-			"integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"flatted": "^3.2.9",
-				"keyv": "^4.5.3",
-				"rimraf": "^3.0.2"
-			},
-			"engines": {
-				"node": "^10.12.0 || >=12.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/globals": {
-			"version": "13.24.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"type-fest": "^0.20.2"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/ts-api-utils": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-			"integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.2.0"
-			}
-		},
-		"node_modules/eslint-plugin-n8n-nodes-base/node_modules/type-fest": {
-			"version": "0.20.2",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -5942,7 +5729,6 @@
 			"resolved": "https://registry.npmjs.org/esprima-next/-/esprima-next-5.8.4.tgz",
 			"integrity": "sha512-8nYVZ4ioIH4Msjb/XmhnBdz5WRRBaYqevKa1cv9nGJdCehMbzZCPNEEnqfLCZVetUVrUPEcb5IYyu1GG4hFqgg==",
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"bin": {
 				"esparse": "bin/esparse.js",
 				"esvalidate": "bin/esvalidate.js"
@@ -6370,7 +6156,6 @@
 			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
 			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"is-callable": "^1.2.7"
 			},
@@ -6435,18 +6220,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-			"dev": true,
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -6525,7 +6308,6 @@
 			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
 			"integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -6554,7 +6336,6 @@
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
@@ -6589,7 +6370,6 @@
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
 				"es-object-atoms": "^1.0.0"
@@ -6775,27 +6555,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/glogg": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/glogg/-/glogg-2.2.0.tgz",
@@ -6814,7 +6573,6 @@
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -6828,14 +6586,6 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/graphemer": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/gulp": {
 			"version": "5.0.1",
@@ -6933,7 +6683,6 @@
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0"
 			},
@@ -6946,7 +6695,6 @@
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -6959,7 +6707,6 @@
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"has-symbols": "^1.0.3"
 			},
@@ -6971,9 +6718,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -7038,9 +6785,9 @@
 			}
 		},
 		"node_modules/ibm-cloud-sdk-core": {
-			"version": "5.4.20",
-			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.20.tgz",
-			"integrity": "sha512-3jdfmJvV67DOlzHfNgLFkRgitmly/qlq/MBqfVuFEugNe4zrYQar8IRIfby635ZpbKR4PmdmRjIjn5f0kQy2Ig==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.5.0.tgz",
+			"integrity": "sha512-ot6sGHAvSnd/ZSU4ZFn+m7i+xcFo3pmA3qm2JmEndDkMsuNR8HLdUeJ5iBbmkUfCGbf2ccTu/GvoJgFetyO6XA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -7048,13 +6795,13 @@
 				"@types/debug": "4.1.12",
 				"@types/node": "18.19.80",
 				"@types/tough-cookie": "4.0.0",
-				"axios": "1.16.1",
+				"axios": "1.18.0",
 				"camelcase": "6.3.0",
 				"debug": "4.3.4",
 				"dotenv": "16.4.5",
 				"extend": "3.0.2",
 				"file-type": "21.3.2",
-				"form-data": "4.0.4",
+				"form-data": "4.0.6",
 				"isstream": "0.1.2",
 				"jsonwebtoken": "9.0.3",
 				"load-esm": "1.0.3",
@@ -7122,24 +6869,6 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
-			}
-		},
-		"node_modules/ibm-cloud-sdk-core/node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/ibm-cloud-sdk-core/node_modules/ms": {
@@ -7323,7 +7052,6 @@
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
 			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
@@ -7359,8 +7087,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/is-bun-module": {
 			"version": "2.0.0",
@@ -7377,7 +7104,6 @@
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
 			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -7451,7 +7177,6 @@
 			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
 			"integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.4",
 				"generator-function": "^2.0.0",
@@ -7484,7 +7209,6 @@
 			"resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
 			"integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"define-properties": "^1.1.3"
@@ -7536,17 +7260,6 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/is-path-inside": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -7562,7 +7275,6 @@
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
 			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"gopd": "^1.2.0",
@@ -7607,7 +7319,6 @@
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
 			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"which-typed-array": "^1.1.16"
 			},
@@ -7685,10 +7396,8 @@
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
 			"integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"node-gyp-build": "^4.8.4"
 			},
@@ -8435,17 +8144,15 @@
 			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
 			"integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/js-base64": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
-			"integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==",
-			"license": "BSD-3-Clause",
-			"peer": true
+			"version": "3.7.8",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+			"integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/js-tiktoken": {
 			"version": "1.0.21",
@@ -8553,7 +8260,6 @@
 			"resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.2.tgz",
 			"integrity": "sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==",
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"jsonrepair": "bin/cli.js"
 			}
@@ -8587,7 +8293,6 @@
 			"resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
 			"integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -8682,9 +8387,9 @@
 			}
 		},
 		"node_modules/langsmith": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.3.tgz",
-			"integrity": "sha512-Gg+IeRGoF1/aStu80aEnIXJCu+N6+4NoV4tAVFS51ZPRBsRa2KG0LkS7K7/ryZ/yES7O9xdqah5QuuWMIeMjQw==",
+			"version": "0.7.14",
+			"resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.14.tgz",
+			"integrity": "sha512-sy6KzzLpO/b1EiCF22A9u37IH1Er4Py9rqepHCuaSlsUjGDam0ez1vDS7sNdvWGADrvYE4mTRQ4ipO4LrD9Mcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8839,8 +8544,7 @@
 			"version": "4.18.1",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
 			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
@@ -8933,11 +8637,10 @@
 			}
 		},
 		"node_modules/luxon": {
-			"version": "3.4.4",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-			"integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+			"integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -8997,7 +8700,6 @@
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -9007,7 +8709,6 @@
 			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
 			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"charenc": "0.0.2",
 				"crypt": "0.0.2",
@@ -9050,7 +8751,6 @@
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
 			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -9060,7 +8760,6 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
 			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mime-db": "1.52.0"
 			},
@@ -9142,45 +8841,63 @@
 			}
 		},
 		"node_modules/n8n-workflow": {
-			"version": "1.120.14",
-			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-1.120.14.tgz",
-			"integrity": "sha512-cnwOzM0/EYr/Mkz0ycO5Fksk3sFdopLut6wpZM1Ls3IF81XfNG2z8ST158pxIvx3D2SQnoW2gvk3tMjLGpFnaA==",
+			"version": "2.28.2",
+			"resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.28.2.tgz",
+			"integrity": "sha512-fGJ6yxRdgeea5EAywfAplYWDLMRNVMZRFikVTFLCBOInxLRDB89LL66sZHx2SC9dl/FALJAGZ6twY5MyUlc+HA==",
 			"license": "SEE LICENSE IN LICENSE.md",
-			"peer": true,
 			"dependencies": {
-				"@n8n/errors": "0.5.0",
-				"@n8n/tournament": "1.0.6",
+				"@n8n/errors": "0.10.0",
+				"@n8n/expression-runtime": "0.19.0",
+				"@n8n/tournament": "1.4.0",
 				"ast-types": "0.16.1",
 				"callsites": "3.1.0",
 				"esprima-next": "5.8.4",
-				"form-data": "4.0.0",
+				"form-data": "4.0.6",
 				"jmespath": "0.16.0",
-				"js-base64": "3.7.2",
+				"js-base64": "3.7.8",
 				"jsonrepair": "3.13.2",
 				"jssha": "3.3.1",
 				"lodash": "4.18.1",
-				"luxon": "3.4.4",
+				"luxon": "3.7.2",
 				"md5": "2.3.0",
 				"recast": "0.22.0",
 				"title-case": "3.0.3",
 				"transliteration": "2.3.5",
+				"uuid": "11.1.1",
 				"xml2js": "0.6.2",
 				"zod": "3.25.67"
 			}
 		},
-		"node_modules/n8n-workflow/node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+		"node_modules/n8n-workflow/node_modules/uuid": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
 			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
 		"node_modules/napi-postinstall": {
@@ -9287,9 +9004,7 @@
 			"version": "4.8.4",
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
 			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"node-gyp-build": "bin.js",
 				"node-gyp-build-optional": "optional.js",
@@ -9351,7 +9066,6 @@
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
 			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1"
@@ -9368,7 +9082,6 @@
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -9378,7 +9091,6 @@
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
 			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.3",
@@ -9799,14 +9511,38 @@
 				"node": "20 || >=22"
 			}
 		},
-		"node_modules/path-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+		"node_modules/pdf-parse": {
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+			"integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
 			"dev": true,
-			"license": "MIT",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@napi-rs/canvas": "0.1.80",
+				"pdfjs-dist": "5.4.296"
+			},
+			"bin": {
+				"pdf-parse": "bin/cli.mjs"
+			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=20.16.0 <21 || >=22.3.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/mehmet-kozan"
+			}
+		},
+		"node_modules/pdfjs-dist": {
+			"version": "5.4.296",
+			"resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+			"integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=20.16.0 || >=22.3.0"
+			},
+			"optionalDependencies": {
+				"@napi-rs/canvas": "^0.1.80"
 			}
 		},
 		"node_modules/picocolors": {
@@ -9909,14 +9645,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.60.0"
+				"playwright-core": "1.61.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -9929,9 +9665,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -9973,7 +9709,6 @@
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
 			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -10173,7 +9908,6 @@
 			"resolved": "https://registry.npmjs.org/recast/-/recast-0.22.0.tgz",
 			"integrity": "sha512-5AAx+mujtXijsEavc5lWXBPQqrM4+Dl5qNH96N2aNeuJFUzpiiToKPsxQD/zAIJHspz7zz0maX0PCtCTFVlixQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"assert": "^2.0.0",
 				"ast-types": "0.15.2",
@@ -10190,7 +9924,6 @@
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
 			"integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"tslib": "^2.0.1"
 			},
@@ -10521,7 +10254,6 @@
 			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
 			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -10546,7 +10278,6 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
 			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
 			"license": "BlueOak-1.0.0",
-			"peer": true,
 			"engines": {
 				"node": ">=11.0.0"
 			}
@@ -10594,7 +10325,6 @@
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -11000,14 +10730,6 @@
 				"b4a": "^1.6.4"
 			}
 		},
-		"node_modules/text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -11168,7 +10890,6 @@
 			"resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.3.5.tgz",
 			"integrity": "sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"yargs": "^17.5.1"
 			},
@@ -11185,7 +10906,6 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -11200,7 +10920,6 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -11459,9 +11178,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-			"integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -11596,7 +11315,6 @@
 			"resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
 			"integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"is-arguments": "^1.0.4",
@@ -11794,11 +11512,10 @@
 			}
 		},
 		"node_modules/which-typed-array": {
-			"version": "1.1.21",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
-			"integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
+			"version": "1.1.22",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+			"integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.9",
@@ -11930,7 +11647,6 @@
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
 			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"sax": ">=0.6.0",
 				"xmlbuilder": "~11.0.0"
@@ -11944,7 +11660,6 @@
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
 			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"nock": "^14.0.16",
 				"prettier": "^3.9.4",
 				"ts-jest": "^29.4.11",
-				"typescript": "5.5.3"
+				"typescript": "^6.0.3"
 			},
 			"engines": {
 				"node": ">=22.0.0"
@@ -11105,9 +11105,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-			"integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"nock": "^14.0.16",
 		"prettier": "^3.9.4",
 		"ts-jest": "^29.4.11",
-		"typescript": "5.5.3"
+		"typescript": "^6.0.3"
 	},
 	"peerDependencies": {
 		"n8n-workflow": "*"

--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
 	"devDependencies": {
 		"@n8n/node-cli": "^0.37.2",
 		"@types/jest": "^29.5.14",
-		"@types/node": "^24.0.1",
-		"eslint": "^9.32.0",
+		"@types/node": "^24.13.2",
+		"eslint": "^9.39.4",
 		"gulp": "^5.0.1",
 		"jest": "^29.7.0",
-		"nock": "^14.0.5",
-		"prettier": "^3.3.2",
-		"ts-jest": "^29.3.2",
+		"nock": "^14.0.16",
+		"prettier": "^3.9.4",
+		"ts-jest": "^29.4.11",
 		"typescript": "5.5.3"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
 	},
 	"devDependencies": {
 		"@n8n/node-cli": "^0.37.2",
-		"@types/jest": "^29.5.14",
+		"@types/jest": "^30.0.0",
 		"@types/node": "^24.13.2",
 		"eslint": "^9.39.4",
 		"gulp": "^5.0.1",
-		"jest": "^29.7.0",
+		"jest": "^30.4.2",
 		"nock": "^14.0.16",
 		"prettier": "^3.9.4",
 		"ts-jest": "^29.4.11",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		]
 	},
 	"devDependencies": {
-		"@n8n/node-cli": "*",
+		"@n8n/node-cli": "^0.37.2",
 		"@types/jest": "^29.5.14",
 		"@types/node": "^24.0.1",
 		"eslint": "^9.32.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
 		"strict": true,
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"ignoreDeprecations": "6.0",
+		"types": ["node", "jest"],
 		"target": "es2019",
 		"lib": ["es2019", "es2020", "es2022.error"],
 		"removeComments": true,


### PR DESCRIPTION
## Dependency updates

Brings dependencies up to date and aligns the build with n8n v2. 

### Changed
- **Pinned `@n8n/node-cli`** `*` → `^0.37.2` - fixes a broken npm ci (used by CI + publish) caused by an inconsistent lockfile.
- **n8n-workflow → v2** (2.28.x via node-cli). Adapted two test helpers to v2 (`IRun.storedAt`, new `ICredentialsHelper` methods). No runtime code changes needed.
- **typescript** 5.5.3 → 6.0.3 (added `ignoreDeprecations: "6.0"` for the `moduleResolution: node` deprecation + explicit `types: ["node","jest"]`).
- **jest** + **@types/jest** → 30.
- **@types/node** → 24.13.2, **nock** → 14.0.16, **ts-jest** → 29.4.11, **prettier** → 3.9.4, **eslint** → 9.39.4, **gulp** → 5.

### Deliberately not taken to latest version
- **eslint stays on 9** - eslint 10 crashes node-cli's bundled `eslint-plugin-n8n-nodes-base` (uses the removed `context.getFilename()`). Revisit when n8n updates the plugin.
- **@types/node stays on 24.x** - must match the Node runtime (CI Node 24.x, `engines >=22`). 

### Verification
- `npm ci`, `npm run build`, `npm run lint` (0 errors), `npm test` all green.
- Manually smoke-tested in a running n8n instance - Apify node loads and executes.

### Follow-ups (not in this PR)
- **Themed node icon** - node-cli 0.37 lints for `{ light, dark }` icon variants; currently 2 non-blocking warnings. Needs a **dark-theme Apify logo SVG** 

fixes: https://github.com/orgs/apify/projects/18/views/2?pane=issue&itemId=201506615&issue=apify%7Cintegrations-team%7C99