### PR TITLE
fix: resource locator links, scrape URL validation, and Run Task buil…

### DIFF
--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -435,6 +435,54 @@ describe('Apify Node', () => {
 
 				expect(scope.isDone()).toBe(true);
 			});
+
+			it('should throw a clear error when the scraper returns no dataset items', async () => {
+				const mockRunActor = fixtures.runActorResult();
+				const mockFinishedRun = fixtures.getSuccessRunResult();
+				const datasetId = mockFinishedRun.data.defaultDatasetId;
+
+				const scope = nock('https://api.apify.com')
+					.post(`/v2/acts/${helpers.consts.WEB_CONTENT_SCRAPER_ACTOR_ID}/runs`)
+					.query({ waitForFinish: 0 })
+					.reply(200, mockRunActor)
+					.get(`/v2/actor-runs/${mockRunActor.data.id}`)
+					.reply(200, mockFinishedRun)
+					.get(`/v2/datasets/${datasetId}/items`)
+					.query({ format: 'json' })
+					.reply(200, []);
+
+				const scrapeSingleUrlWorkflow = require('./workflows/actors/scrape-single-url.workflow.json');
+
+				await expect(
+					executeWorkflow({
+						credentialsHelper,
+						workflow: scrapeSingleUrlWorkflow,
+					}),
+				).rejects.toThrow(/No content was scraped/);
+
+				expect(scope.isDone()).toBe(true);
+			});
+
+			it('should reject an obviously invalid URL before calling the API', async () => {
+				const baseWorkflow = require('./workflows/actors/scrape-single-url.workflow.json');
+				const makeWorkflowWithUrl = (url: string) => ({
+					...baseWorkflow,
+					nodes: baseWorkflow.nodes.map((node: any) =>
+						node.name === 'Scrape single URL'
+							? { ...node, parameters: { ...node.parameters, url } }
+							: node,
+					),
+				});
+
+				for (const badUrl of ['https://bla', 'https://-.com', 'not-a-url', 'ftp://example.com']) {
+					await expect(
+						executeWorkflow({
+							credentialsHelper,
+							workflow: makeWorkflowWithUrl(badUrl),
+						}),
+					).rejects.toThrow(/Invalid URL/);
+				}
+			});
 		});
 	});
 

--- a/nodes/Apify/__tests__/tsconfig.json
+++ b/nodes/Apify/__tests__/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"types": ["node", "jest"],
+		"noEmit": true,
+		"rootDir": "../../.."
+	},
+	"include": ["**/*.ts", "../**/*.ts"],
+	"exclude": []
+}

--- a/nodes/Apify/__tests__/workflows/actors/scrape-single-url.workflow.json
+++ b/nodes/Apify/__tests__/workflows/actors/scrape-single-url.workflow.json
@@ -4,7 +4,8 @@
 		{
 			"parameters": {
 				"resource": "Actors",
-				"operation": "Scrape single URL"
+				"operation": "Scrape single URL",
+				"url": "https://docs.apify.com/academy/web-scraping-for-beginners"
 			},
 			"id": "cde14951-f922-4710-b3c5-dc913fdcc10b",
 			"name": "Scrape single URL",

--- a/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/properties.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task-and-get-dataset/properties.ts
@@ -75,10 +75,9 @@ timeout specified in the task settings.`,
 		},
 	},
 	{
-		displayName: 'Build',
+		displayName: 'Build Tag',
 		name: 'build',
-		description: `Specifies the Actor build to run. It can be either a build tag or build
-number. By default, the run uses the build specified in the task
+		description: `Specifies the Actor build tag to run. By default, the run uses the build specified in the task
 settings (typically \`latest\`).`,
 		default: '',
 		type: 'string',

--- a/nodes/Apify/resources/actor-tasks/run-task/properties.ts
+++ b/nodes/Apify/resources/actor-tasks/run-task/properties.ts
@@ -89,10 +89,9 @@ timeout specified in the task settings.`,
 		},
 	},
 	{
-		displayName: 'Build',
+		displayName: 'Build Tag',
 		name: 'build',
-		description: `Specifies the Actor build to run. It can be either a build tag or build
-number. By default, the run uses the build specified in the task
+		description: `Specifies the Actor build tag to run. By default, the run uses the build specified in the task
 settings (typically \`latest\`).`,
 		default: '',
 		type: 'string',

--- a/nodes/Apify/resources/actorResourceLocator.ts
+++ b/nodes/Apify/resources/actorResourceLocator.ts
@@ -55,7 +55,7 @@ const resourceLocatorProperty: INodeProperties = {
 				},
 			],
 			placeholder: 'NVCnbrChXaPbhVs8bISltEhngFg',
-			url: '=http:/console.apify.com/actors/{{ $value }}/input',
+			url: '=https://console.apify.com/actors/{{$value}}/input',
 		},
 	],
 };

--- a/nodes/Apify/resources/actorTaskResourceLocator.ts
+++ b/nodes/Apify/resources/actorTaskResourceLocator.ts
@@ -55,7 +55,7 @@ const resourceLocatorProperty: INodeProperties = {
 				},
 			],
 			placeholder: 'WAtmhr6rhfBnwqKDY',
-			url: '=http:/console.apify.com/actors/tasks/{{ $value }}/input',
+			url: '=https://console.apify.com/actors/tasks/{{$value}}/input',
 		},
 	],
 };

--- a/nodes/Apify/resources/actors/scrape-single-url/execute.ts
+++ b/nodes/Apify/resources/actors/scrape-single-url/execute.ts
@@ -1,4 +1,9 @@
-import { IExecuteFunctions, INodeExecutionData, NodeApiError } from 'n8n-workflow';
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	NodeApiError,
+	NodeOperationError,
+} from 'n8n-workflow';
 import { apiRequest, pollRunStatus } from '../../../resources/genericFunctions';
 import { consts } from '../../../helpers';
 
@@ -8,6 +13,24 @@ export async function scrapeSingleUrl(
 ): Promise<INodeExecutionData> {
 	const url = this.getNodeParameter('url', i) as string;
 	const crawlerType = this.getNodeParameter('crawlerType', i, 'cheerio') as string;
+
+	const isValidHostname = (hostname: string): boolean =>
+		/^(?=.{1,253}$)((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$/.test(hostname);
+	try {
+		const parsedUrl = new URL(url);
+		if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+			throw new Error('Unsupported protocol');
+		}
+		if (!isValidHostname(parsedUrl.hostname)) {
+			throw new Error('Invalid hostname');
+		}
+	} catch {
+		throw new NodeOperationError(
+			this.getNode(),
+			`Invalid URL: "${url}". Provide a full, valid URL including a domain name, e.g. https://example.com.`,
+			{ itemIndex: i },
+		);
+	}
 
 	try {
 		const input = {
@@ -58,6 +81,13 @@ export async function scrapeSingleUrl(
 			qs: { format: 'json' },
 			timeout: consts.DATASET_REQUEST_TIMEOUT_MS,
 		});
+
+		if (!item) {
+			throw new NodeApiError(this.getNode(), {
+				message:
+					'No content was scraped from the provided URL. Make sure the URL is valid and publicly accessible.',
+			});
+		}
 
 		delete item.text;
 

--- a/nodes/Apify/resources/keyValueStoreRecordKeyResourceLocator.ts
+++ b/nodes/Apify/resources/keyValueStoreRecordKeyResourceLocator.ts
@@ -33,7 +33,7 @@ const resourceLocatorProperty: INodeProperties = {
 				},
 			],
 			placeholder: 'RECORD_KEY',
-			url: '=https://api.apify.com/v2/key-value-stores/{{ $value }}/records/{{ $value }}',
+			url: '=https://api.apify.com/v2/key-value-stores/{{$parameter["storeId"]}}/records/{{$value}}',
 		},
 	],
 };

--- a/nodes/Apify/resources/keyValueStoreResourceLocator.ts
+++ b/nodes/Apify/resources/keyValueStoreResourceLocator.ts
@@ -32,7 +32,7 @@ const resourceLocatorProperty: INodeProperties = {
 				},
 			],
 			placeholder: 'dmXls2mjfQVdzfrC6',
-			url: '=https://console.apify.com/storage/key-value-stores/{{ $value }}',
+			url: '=https://console.apify.com/storage/key-value-stores/{{$value}}',
 		},
 	],
 };

--- a/nodes/Apify/resources/runResourceLocator.ts
+++ b/nodes/Apify/resources/runResourceLocator.ts
@@ -53,7 +53,7 @@ const resourceLocatorProperty: INodeProperties = {
 				},
 			],
 			placeholder: 'WAtmhr6rhfBnwqKDY',
-			url: '=http:/console.apify.com/actors/{{ $value }}/runs/{{ $value }}#log',
+			url: '=https://console.apify.com/actors/runs/{{$value}}#log',
 		},
 	],
 };

--- a/nodes/Apify/resources/userActorResourceLocator.ts
+++ b/nodes/Apify/resources/userActorResourceLocator.ts
@@ -55,7 +55,7 @@ const resourceLocatorProperty: INodeProperties = {
 				},
 			],
 			placeholder: 'NVCnbrChXaPbhVs8bISltEhngFg',
-			url: '=http:/console.apify.com/actors/{{ $value }}/input',
+			url: '=https://console.apify.com/actors/{{$value}}/input',
 		},
 	],
 };


### PR DESCRIPTION
Three small bugs found while testing, plus a test-tooling tweak.

- **Resource locator "open" links** - fixed the broken console links in all 6 locators (actor, task, run, user-actor, key-value-store, record-key)
- **Scrape Single URL - validation** - invalid URLs  are now rejected before being sent to Apify.
- **Scrape Single URL - crash** - an empty scrape result no longer crashes with *"Cannot convert undefined or null to object"*; it returns a clear error instead.
- **Run Task** - build field renamed to **"Build Tag"** to match Run Actor (label only, behaviour unchanged).
- **Tests tsconfig** - added `__tests__/tsconfig.json` so editors resolve jest globals. Editor-only - not used by build/CI.

fixes: https://github.com/orgs/apify/projects/18/views/2?pane=issue&itemId=176597533&issue=apify%7Capify-integrations-backend%7C497