### PR TITLE
fix: small node improvements

### DIFF
--- a/credentials/ApifyApi.credentials.ts
+++ b/credentials/ApifyApi.credentials.ts
@@ -1,4 +1,11 @@
-import type { IAuthenticateGeneric, ICredentialType, INodeProperties } from 'n8n-workflow';
+import type {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+import { APIFY_API_URL } from '../nodes/Apify/helpers/consts';
 // eslint-disable-next-line
 export class ApifyApi implements ICredentialType {
 	name = 'apifyApi';
@@ -23,6 +30,13 @@ export class ApifyApi implements ICredentialType {
 			headers: {
 				Authorization: '=Bearer {{$credentials.apiKey}}',
 			},
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: APIFY_API_URL,
+			url: '/v2/users/me',
 		},
 	};
 }

--- a/nodes/Apify/Apify.node.json
+++ b/nodes/Apify/Apify.node.json
@@ -10,6 +10,10 @@
 		"Utility",
 		"Data & Storage"
 	],
+	"subcategories": {
+		"AI": ["Tools"],
+		"Tools": ["Other Tools"]
+	},
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/nodes/Apify/ApifyTrigger.node.json
+++ b/nodes/Apify/ApifyTrigger.node.json
@@ -3,6 +3,9 @@
 	"nodeVersion": "1.0",
 	"codexVersion": "1.0",
 	"categories": ["Development", "Data & Storage", "Utility"],
+	"subcategories": {
+		"AI": ["Tools"]
+	},
 	"resources": {
 		"credentialDocumentation": [
 			{

--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -621,8 +621,88 @@ describe('Apify Node', () => {
 
 				const data = getTaskData(nodeResult);
 				expect(typeof data).toBe('object');
-				const { text, ...mockedItemWithoutText } = mockItems[0];
-				expect(data).toEqual(mockedItemWithoutText);
+				// Default output format is markdown, so only the markdown field is returned.
+				expect(data).toEqual({ markdown: mockItems[0].markdown });
+
+				expect(scope.isDone()).toBe(true);
+			});
+
+			it('should return only the selected output format (html)', async () => {
+				const mockRunActor = fixtures.runActorResult();
+				const mockFinishedRun = fixtures.getSuccessRunResult();
+				const mockItems = fixtures.getScrapeSingleUrlItemsResult();
+
+				const datasetId = mockFinishedRun.data.defaultDatasetId;
+
+				const scope = nock('https://api.apify.com')
+					.post(`/v2/acts/${helpers.consts.WEB_CONTENT_SCRAPER_ACTOR_ID}/runs`)
+					.query({ waitForFinish: 0 })
+					.reply(200, mockRunActor)
+					.get(`/v2/actor-runs/${mockRunActor.data.id}`)
+					.reply(200, mockFinishedRun)
+					.get(`/v2/datasets/${datasetId}/items`)
+					.query({ format: 'json' })
+					.reply(200, mockItems);
+
+				const baseWorkflow = require('./workflows/actors/scrape-single-url.workflow.json');
+				const workflow = {
+					...baseWorkflow,
+					nodes: baseWorkflow.nodes.map((node: any) =>
+						node.name === 'Scrape single URL'
+							? { ...node, parameters: { ...node.parameters, outputFormat: 'html' } }
+							: node,
+					),
+				};
+
+				const { executionData } = await executeWorkflow({ credentialsHelper, workflow });
+
+				const nodeResults = getRunTaskDataByNodeName(executionData, 'Scrape single URL');
+				const [nodeResult] = nodeResults;
+				expect(nodeResult.executionStatus).toBe('success');
+
+				const data = getTaskData(nodeResult);
+				expect(data).toEqual({ html: mockItems[0].html });
+
+				expect(scope.isDone()).toBe(true);
+			});
+
+			it('should include metadata (without other content formats) when includeMetadata is enabled', async () => {
+				const mockRunActor = fixtures.runActorResult();
+				const mockFinishedRun = fixtures.getSuccessRunResult();
+				const mockItems = fixtures.getScrapeSingleUrlItemsResult();
+
+				const datasetId = mockFinishedRun.data.defaultDatasetId;
+
+				const scope = nock('https://api.apify.com')
+					.post(`/v2/acts/${helpers.consts.WEB_CONTENT_SCRAPER_ACTOR_ID}/runs`)
+					.query({ waitForFinish: 0 })
+					.reply(200, mockRunActor)
+					.get(`/v2/actor-runs/${mockRunActor.data.id}`)
+					.reply(200, mockFinishedRun)
+					.get(`/v2/datasets/${datasetId}/items`)
+					.query({ format: 'json' })
+					.reply(200, mockItems);
+
+				const baseWorkflow = require('./workflows/actors/scrape-single-url.workflow.json');
+				const workflow = {
+					...baseWorkflow,
+					nodes: baseWorkflow.nodes.map((node: any) =>
+						node.name === 'Scrape single URL'
+							? { ...node, parameters: { ...node.parameters, includeMetadata: true } }
+							: node,
+					),
+				};
+
+				const { executionData } = await executeWorkflow({ credentialsHelper, workflow });
+
+				const nodeResults = getRunTaskDataByNodeName(executionData, 'Scrape single URL');
+				const [nodeResult] = nodeResults;
+				expect(nodeResult.executionStatus).toBe('success');
+
+				const data = getTaskData(nodeResult);
+				// Metadata plus only the default (markdown) content format - no html/text.
+				const { text, html, markdown, ...metadata } = mockItems[0];
+				expect(data).toEqual({ ...metadata, markdown });
 
 				expect(scope.isDone()).toBe(true);
 			});

--- a/nodes/Apify/__tests__/utils/executeWorkflow.ts
+++ b/nodes/Apify/__tests__/utils/executeWorkflow.ts
@@ -124,7 +124,8 @@ export const executeWorkflow = async ({
 			options?: IGetNodeParameterOptions,
 		) => {
 			if (options?.extractValue) return node.parameters[parameterName].value;
-			return node.parameters[parameterName];
+			// Mirror n8n: fall back to the provided default when the parameter is unset.
+			return node.parameters[parameterName] ?? fallbackValue;
 		},
 		getInputData: (): INodeExecutionData[] => {
 			// Provide at least one empty item so loops like `for (let i = 0; i < items.length; i++)`

--- a/nodes/Apify/resources/actors/scrape-single-url/execute.ts
+++ b/nodes/Apify/resources/actors/scrape-single-url/execute.ts
@@ -13,6 +13,8 @@ export async function scrapeSingleUrl(
 ): Promise<INodeExecutionData> {
 	const url = this.getNodeParameter('url', i) as string;
 	const crawlerType = this.getNodeParameter('crawlerType', i, 'cheerio') as string;
+	const outputFormat = this.getNodeParameter('outputFormat', i, 'markdown') as string;
+	const includeMetadata = this.getNodeParameter('includeMetadata', i, false) as boolean;
 
 	const isValidHostname = (hostname: string): boolean =>
 		/^(?=.{1,253}$)((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$/.test(hostname);
@@ -43,8 +45,8 @@ export async function scrapeSingleUrl(
 				useApifyProxy: true,
 			},
 			removeCookieWarnings: true,
-			saveHtml: true,
-			saveMarkdown: true,
+			saveHtml: outputFormat === 'html',
+			saveMarkdown: outputFormat === 'markdown',
 		};
 
 		// Run the actor and do not wait for finish
@@ -89,9 +91,20 @@ export async function scrapeSingleUrl(
 			});
 		}
 
-		delete item.text;
+		const content = { [outputFormat]: item[outputFormat] };
 
-		return { json: { ...item } };
+		if (!includeMetadata) {
+			return { json: content };
+		}
+
+		// The scraper returns all content fields (text/html/markdown) regardless of the save
+		// flags, so strip them from the metadata and keep only the selected format.
+		const metadata = { ...item };
+		delete metadata.text;
+		delete metadata.html;
+		delete metadata.markdown;
+
+		return { json: { ...metadata, ...content } };
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error);
 	}

--- a/nodes/Apify/resources/actors/scrape-single-url/properties.ts
+++ b/nodes/Apify/resources/actors/scrape-single-url/properties.ts
@@ -44,4 +44,48 @@ export const properties: INodeProperties[] = [
 			},
 		},
 	},
+	{
+		displayName: 'Output Format',
+		name: 'outputFormat',
+		type: 'options',
+		default: 'markdown',
+		description: 'Which content format to return. Markdown is recommended for AI agents and LLMs.',
+		options: [
+			{
+				name: 'Markdown',
+				value: 'markdown',
+				description: 'Clean markdown - best for AI agents and LLMs',
+			},
+			{
+				name: 'HTML',
+				value: 'html',
+				description: 'Raw HTML - best for programmatic processing',
+			},
+			{
+				name: 'Text',
+				value: 'text',
+				description: 'Plain text with no formatting',
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['Actors'],
+				operation: ['Scrape single URL'],
+			},
+		},
+	},
+	{
+		displayName: 'Include Metadata',
+		name: 'includeMetadata',
+		type: 'boolean',
+		default: false,
+		description:
+			'Whether to include page metadata (URL, crawl details, page metadata) alongside the content. Leave off for lean output best suited to AI agents; turn on when you need the full page context.',
+		displayOptions: {
+			show: {
+				resource: ['Actors'],
+				operation: ['Scrape single URL'],
+			},
+		},
+	},
 ];


### PR DESCRIPTION
- Added credential test block to ApifyApi credentials: https://github.com/apify/integrations-team/issues/63
- Let "Scrape single URL" choose which output format to return: https://github.com/apify/integrations-team/issues/66
- Add subcategories to node.json files for AI tool panel grouping: https://github.com/apify/integrations-team/issues/71

