### PR TITLE
fix: revert to metadata in scrape url response

### DIFF
--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -621,13 +621,14 @@ describe('Apify Node', () => {
 
 				const data = getTaskData(nodeResult);
 				expect(typeof data).toBe('object');
-				// Default output format is markdown, so only the markdown field is returned.
-				expect(data).toEqual({ markdown: mockItems[0].markdown });
+				// Default output format is markdown; other content formats are stripped.
+				const { text, html, markdown, ...metadata } = mockItems[0];
+				expect(data).toEqual({ ...metadata, markdown });
 
 				expect(scope.isDone()).toBe(true);
 			});
 
-			it('should return only the selected output format (html)', async () => {
+			it('should return metadata with only the selected output format (html)', async () => {
 				const mockRunActor = fixtures.runActorResult();
 				const mockFinishedRun = fixtures.getSuccessRunResult();
 				const mockItems = fixtures.getScrapeSingleUrlItemsResult();
@@ -661,48 +662,9 @@ describe('Apify Node', () => {
 				expect(nodeResult.executionStatus).toBe('success');
 
 				const data = getTaskData(nodeResult);
-				expect(data).toEqual({ html: mockItems[0].html });
-
-				expect(scope.isDone()).toBe(true);
-			});
-
-			it('should include metadata (without other content formats) when includeMetadata is enabled', async () => {
-				const mockRunActor = fixtures.runActorResult();
-				const mockFinishedRun = fixtures.getSuccessRunResult();
-				const mockItems = fixtures.getScrapeSingleUrlItemsResult();
-
-				const datasetId = mockFinishedRun.data.defaultDatasetId;
-
-				const scope = nock('https://api.apify.com')
-					.post(`/v2/acts/${helpers.consts.WEB_CONTENT_SCRAPER_ACTOR_ID}/runs`)
-					.query({ waitForFinish: 0 })
-					.reply(200, mockRunActor)
-					.get(`/v2/actor-runs/${mockRunActor.data.id}`)
-					.reply(200, mockFinishedRun)
-					.get(`/v2/datasets/${datasetId}/items`)
-					.query({ format: 'json' })
-					.reply(200, mockItems);
-
-				const baseWorkflow = require('./workflows/actors/scrape-single-url.workflow.json');
-				const workflow = {
-					...baseWorkflow,
-					nodes: baseWorkflow.nodes.map((node: any) =>
-						node.name === 'Scrape single URL'
-							? { ...node, parameters: { ...node.parameters, includeMetadata: true } }
-							: node,
-					),
-				};
-
-				const { executionData } = await executeWorkflow({ credentialsHelper, workflow });
-
-				const nodeResults = getRunTaskDataByNodeName(executionData, 'Scrape single URL');
-				const [nodeResult] = nodeResults;
-				expect(nodeResult.executionStatus).toBe('success');
-
-				const data = getTaskData(nodeResult);
-				// Metadata plus only the default (markdown) content format - no html/text.
+				// Metadata plus only the selected (html) content format - no markdown/text.
 				const { text, html, markdown, ...metadata } = mockItems[0];
-				expect(data).toEqual({ ...metadata, markdown });
+				expect(data).toEqual({ ...metadata, html });
 
 				expect(scope.isDone()).toBe(true);
 			});

--- a/nodes/Apify/__tests__/Apify.node.spec.ts
+++ b/nodes/Apify/__tests__/Apify.node.spec.ts
@@ -669,6 +669,48 @@ describe('Apify Node', () => {
 				expect(scope.isDone()).toBe(true);
 			});
 
+			it('should return metadata with only the selected output format (text)', async () => {
+				const mockRunActor = fixtures.runActorResult();
+				const mockFinishedRun = fixtures.getSuccessRunResult();
+				const mockItems = fixtures.getScrapeSingleUrlItemsResult();
+
+				const datasetId = mockFinishedRun.data.defaultDatasetId;
+
+				const scope = nock('https://api.apify.com')
+					.post(`/v2/acts/${helpers.consts.WEB_CONTENT_SCRAPER_ACTOR_ID}/runs`)
+					.query({ waitForFinish: 0 })
+					.reply(200, mockRunActor)
+					.get(`/v2/actor-runs/${mockRunActor.data.id}`)
+					.reply(200, mockFinishedRun)
+					.get(`/v2/datasets/${datasetId}/items`)
+					.query({ format: 'json' })
+					.reply(200, mockItems);
+
+				const baseWorkflow = require('./workflows/actors/scrape-single-url.workflow.json');
+				const workflow = {
+					...baseWorkflow,
+					nodes: baseWorkflow.nodes.map((node: any) =>
+						node.name === 'Scrape single URL'
+							? { ...node, parameters: { ...node.parameters, outputFormat: 'text' } }
+							: node,
+					),
+				};
+
+				const { executionData } = await executeWorkflow({ credentialsHelper, workflow });
+
+				const nodeResults = getRunTaskDataByNodeName(executionData, 'Scrape single URL');
+				const [nodeResult] = nodeResults;
+				expect(nodeResult.executionStatus).toBe('success');
+
+				const data = getTaskData(nodeResult);
+				// text has no saveText actor input flag - it relies on the scraper
+				// returning every content field. Other formats are still stripped.
+				const { text, html, markdown, ...metadata } = mockItems[0];
+				expect(data).toEqual({ ...metadata, text });
+
+				expect(scope.isDone()).toBe(true);
+			});
+
 			it('should throw a clear error when the scraper returns no dataset items', async () => {
 				const mockRunActor = fixtures.runActorResult();
 				const mockFinishedRun = fixtures.getSuccessRunResult();

--- a/nodes/Apify/resources/actors/scrape-single-url/execute.ts
+++ b/nodes/Apify/resources/actors/scrape-single-url/execute.ts
@@ -14,7 +14,6 @@ export async function scrapeSingleUrl(
 	const url = this.getNodeParameter('url', i) as string;
 	const crawlerType = this.getNodeParameter('crawlerType', i, 'cheerio') as string;
 	const outputFormat = this.getNodeParameter('outputFormat', i, 'markdown') as string;
-	const includeMetadata = this.getNodeParameter('includeMetadata', i, false) as boolean;
 
 	const isValidHostname = (hostname: string): boolean =>
 		/^(?=.{1,253}$)((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$/.test(hostname);
@@ -92,10 +91,6 @@ export async function scrapeSingleUrl(
 		}
 
 		const content = { [outputFormat]: item[outputFormat] };
-
-		if (!includeMetadata) {
-			return { json: content };
-		}
 
 		// The scraper returns all content fields (text/html/markdown) regardless of the save
 		// flags, so strip them from the metadata and keep only the selected format.

--- a/nodes/Apify/resources/actors/scrape-single-url/properties.ts
+++ b/nodes/Apify/resources/actors/scrape-single-url/properties.ts
@@ -74,18 +74,4 @@ export const properties: INodeProperties[] = [
 			},
 		},
 	},
-	{
-		displayName: 'Include Metadata',
-		name: 'includeMetadata',
-		type: 'boolean',
-		default: false,
-		description:
-			'Whether to include page metadata (URL, crawl details, page metadata) alongside the content. Leave off for lean output best suited to AI agents; turn on when you need the full page context.',
-		displayOptions: {
-			show: {
-				resource: ['Actors'],
-				operation: ['Scrape single URL'],
-			},
-		},
-	},
 ];


### PR DESCRIPTION
Revert the case where I stripped metadata when doing the html/markdown/text response for scrape single url. 
If we want to have the option to trim the metadata for LLMs, we can add a field 'Exclude metadata', and set it to false by default, so users can choose and the existing behaviour won't be broken. This just reverts it how it was before. 

Ticket that caused the chage was this - https://github.com/orgs/apify/projects/18/views/2?filterQuery=n8n&pane=issue&itemId=181802439&issue=apify%7Cintegrations-team%7C66