### PR TITLE
chore: require minimum release age for npm installs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=1
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -21,14 +21,8 @@
 		"url": "https://github.com/apify/n8n-nodes-apify.git"
 	},
 	"engines": {
-		"node": ">=22.0.0"
-	},
-	"devEngines": {
-		"packageManager": {
-			"name": "npm",
-			"version": ">=11.10.0",
-			"onFail": "error"
-		}
+		"node": ">=22.0.0",
+		"npm": ">=11.10.0"
 	},
 	"packageManager": "npm@11.19.0",
 	"main": "index.js",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,14 @@
 		"url": "https://github.com/apify/n8n-nodes-apify.git"
 	},
 	"engines": {
-		"node": ">=22.0.0",
-		"npm": ">=11.10.0"
+		"node": ">=22.0.0"
+	},
+	"devEngines": {
+		"packageManager": {
+			"name": "npm",
+			"version": ">=11.10.0",
+			"onFail": "error"
+		}
 	},
 	"packageManager": "npm@11.19.0",
 	"main": "index.js",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
 		"url": "https://github.com/apify/n8n-nodes-apify.git"
 	},
 	"engines": {
-		"node": ">=22.0.0"
+		"node": ">=22.0.0",
+		"npm": ">=11.10.0"
 	},
-	"packageManager": "npm@10.8.2",
+	"packageManager": "npm@11.19.0",
 	"main": "index.js",
 	"scripts": {
 		"build": "n8n-node build",


### PR DESCRIPTION
Closes #50

Adds a package-manager-level release cooldown so npm won't resolve package versions younger than 1 day. Org requirement: apify/apify-core#26736.

- **`.npmrc`** (new): `min-release-age=1`, `engine-strict=true`
- **`package.json`**: add `engines.npm` `>=11.10.0`, bump `packageManager` `npm@10.8.2` → `npm@11.19.0`

The npm bump is required: `min-release-age` landed in npm 11.10.0 and older npm ignores it silently, so with the previous `npm@10.8.2` pin the setting would have been inert. `engines.npm` + `engine-strict` make that a hard `EBADENGINE` failure instead.

Node is untouched — npm 11 runs on Node >=22.9, and `engines.node` stays at `>=22.0.0`.

**Scope:** this gates resolution (`npm install`, `npm update`), not `npm ci`, which installs from the lockfile. Gating the lockfile is Renovate's `minimumReleaseAge` — #12, landing next.

**Verified:** `npm ci --dry-run` clean at 814 packages with and without `--engine-strict`; the same tree under npm 10.8.2 fails with `EBADENGINE`. CI runs Node 24.x → npm 11.17.0, so it satisfies the floor.

Note for sibling repos: the value in apify/apify-core#26736 (`min-release-age=1d`) is invalid — npm rejects the suffix. Use plain `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
